### PR TITLE
Refactor test tags in every activities to use a more modular (though not perfect) option

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/EditProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/EditProfileActivityTest.kt
@@ -7,6 +7,14 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Buttons.Companion.EDIT
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Buttons.Companion.SAVE
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.EMAIL
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.FIRST_NAME
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.LAST_NAME
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_LABEL
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_PICTURE
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,119 +26,111 @@ class EditProfileActivityTest {
     val composeTestRule = createEmptyComposeRule()
 
     @Test
-    fun onCreateShowsErrorIfNoEmailPassed() {
-        val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
-        ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
-            composeTestRule.onNodeWithTag("column").assertExists("Column elem does not exist")
-            composeTestRule.onNodeWithTag("column").assertExists("Column elem does not exist")
-            composeTestRule.onNodeWithTag("title row").assertExists("Title row elem does not exist")
-            composeTestRule.onNodeWithTag("email row").assertExists("Email row elem does not exist")
-            composeTestRule.onNodeWithTag("first name row")
-                .assertExists("First name row elem does not exist")
-            composeTestRule.onNodeWithTag("last name row")
-                .assertExists("Last name row elem does not exist")
-            composeTestRule.onNodeWithTag("favorite sport row")
-                .assertExists("Fav sport row elem does not exist")
-        }
-    }
-
-    @Test
     fun correctInitialScreenContent() {
+        val initiallyDisplayed = listOf(
+            PROFILE_LABEL,
+            PROFILE_PICTURE,
+
+            EMAIL.LABEL,
+            EMAIL.TEXT,
+
+            FIRST_NAME.LABEL,
+            FIRST_NAME.TEXT,
+
+            LAST_NAME.LABEL,
+            LAST_NAME.TEXT,
+
+            SPORT.LABEL,
+            SPORT.TEXT,
+
+            EDIT
+        )
+
+        val initiallyNotDisplayed = listOf(
+            FIRST_NAME.FIELD,
+            LAST_NAME.FIELD,
+            SPORT.FIELD,
+
+            SAVE
+        )
+
         val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
         val email = "example@email.com"
         editProfileIntent.putExtra("email", email)
         ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
-            composeTestRule.onNodeWithTag("column").assertExists("Column elem does not exist")
-            composeTestRule.onNodeWithTag("column").assertExists("Column elem does not exist")
-            composeTestRule.onNodeWithTag("title row").assertExists("Title row elem does not exist")
-            composeTestRule.onNodeWithTag("email row").assertExists("Email row elem does not exist")
-            composeTestRule.onNodeWithTag("first name row")
-                .assertExists("First name row elem does not exist")
-            composeTestRule.onNodeWithTag("last name row")
-                .assertExists("Last name row elem does not exist")
-            composeTestRule.onNodeWithTag("favorite sport row")
-                .assertExists("Fav sport row elem does not exist")
+            initiallyDisplayed.forEach { tag ->
+                // assertIsDisplayed() behaves strangely with components that are empty (empty Text()
+                // components for example, or Text() components whose text is loaded asynchronously)
+                composeTestRule.onNodeWithTag(tag).assertExists()
+            }
 
-            //content of title row
-            composeTestRule.onNodeWithText("My Profile").assertIsDisplayed()
-            composeTestRule.onNodeWithTag("profile pic").assertIsDisplayed()
+            initiallyNotDisplayed.forEach { tag ->
+                composeTestRule.onNodeWithTag(tag).assertDoesNotExist()
+            }
 
-            //content of email row
-            composeTestRule.onNodeWithText("Email: ").assertIsDisplayed()
-            composeTestRule.onNodeWithTag("email address").assertIsDisplayed()
-
-            //content of first name row
-            composeTestRule.onNodeWithText("First name: ").assertIsDisplayed()
-//            composeTestRule.onNodeWithTag("saved first name").assertIsDisplayed()
-
-            //content of last name row
-            composeTestRule.onNodeWithText("Last name: ").assertIsDisplayed()
-//            composeTestRule.onNodeWithTag("saved last name").assertIsDisplayed()
-
-            //content of sport row
-            composeTestRule.onNodeWithText("Favorite sport: ").assertIsDisplayed()
-//            composeTestRule.onNodeWithTag("saved favorite sport").assertIsDisplayed()
         }
     }
 
     @Test
     fun editButtonClickActivatesCorrectElements() {
+        val displayedAfterEditButtonClicked = listOf(
+            FIRST_NAME.FIELD,
+            LAST_NAME.FIELD,
+            SPORT.FIELD,
+
+            SAVE
+        )
+
         val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
         val email = "example@email.com"
         editProfileIntent.putExtra("email", email)
         ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
-            composeTestRule.onNodeWithTag("edit button")
+            composeTestRule.onNodeWithTag(EDIT)
                 .assertIsDisplayed()
                 .performClick()
 
-            composeTestRule.onNodeWithTag("editable first name").assertIsDisplayed()
-            composeTestRule.onNodeWithTag("editable last name").assertIsDisplayed()
-            composeTestRule.onNodeWithTag("editable favorite sport").assertIsDisplayed()
+            displayedAfterEditButtonClicked.forEach { tag ->
+                composeTestRule.onNodeWithTag(tag).assertIsDisplayed()
+            }
         }
     }
 
     @Test
     fun editedFieldsSavedCorrectly() {
+        val newValues = mapOf(
+            FIRST_NAME to "Updated first name",
+            LAST_NAME to "Updated last name",
+            SPORT to "Updated favorite sport"
+        )
+
         val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
         val email = "example@email.com"
         editProfileIntent.putExtra("email", email)
         ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
             //change to edit mode
-            composeTestRule.onNodeWithTag("edit button")
+            composeTestRule.onNodeWithTag(EDIT)
                 .assertIsDisplayed()
                 .performClick()
 
             //edit text fields
-            composeTestRule.onNodeWithTag("editable first name")
-                .performTextClearance()
-            composeTestRule.onNodeWithTag("editable first name")
-                .performTextInput("Updated first name")
-            Espresso.closeSoftKeyboard()
-
-            composeTestRule.onNodeWithTag("editable last name")
-                .performTextClearance()
-            composeTestRule.onNodeWithTag("editable last name")
-                .performTextInput("Updated last name")
-            Espresso.closeSoftKeyboard()
-
-            composeTestRule.onNodeWithTag("editable favorite sport")
-                .performTextClearance()
-            composeTestRule.onNodeWithTag("editable favorite sport")
-                .performTextInput("Updated favorite sport")
-            Espresso.closeSoftKeyboard()
+            newValues.forEach { (field, newValue) ->
+                composeTestRule.onNodeWithTag(field.FIELD)
+                    .performTextClearance()
+                composeTestRule.onNodeWithTag(field.FIELD)
+                    .performTextInput(newValue)
+                Espresso.closeSoftKeyboard()
+            }
 
             //save updated profile
-            composeTestRule.onNodeWithTag("save button")
+            composeTestRule.onNodeWithTag(SAVE)
                 .assertIsDisplayed()
                 .performClick()
 
             //check that the updated fields are saved
-            composeTestRule.onNodeWithTag("saved first name")
-                .assertTextEquals("Updated first name")
-            composeTestRule.onNodeWithTag("saved last name")
-                .assertTextEquals("Updated last name")
-            composeTestRule.onNodeWithTag("saved favorite sport")
-                .assertTextEquals("Updated favorite sport")
+            newValues.forEach { (field, newValue) ->
+                composeTestRule.onNodeWithTag(field.TEXT)
+                    .assertTextEquals(newValue)
+            }
         }
     }
 }

--- a/app/src/androidTest/java/com/github/sdpcoachme/LoginActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/LoginActivityTest.kt
@@ -10,22 +10,23 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.*
+import com.github.sdpcoachme.LoginActivity.TestTags.Buttons.Companion.DELETE_ACCOUNT
+import com.github.sdpcoachme.LoginActivity.TestTags.Buttons.Companion.SIGN_OUT
+import com.github.sdpcoachme.LoginActivity.TestTags.Companion.INFO_TEXT
 import com.google.firebase.auth.FirebaseAuth
-import junit.framework.TestCase
 import org.hamcrest.CoreMatchers
 import org.hamcrest.core.AllOf.allOf
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+// Since those tests use UI Automator, we need to enable testTagsAsResourceId in the corresponding activity
+// in order to be able to find the UI elements by their tags.
 @RunWith(AndroidJUnit4::class)
 open class LoginActivityTest {
     private val launchTimeout = 5000L
     private lateinit var device: UiDevice
-    private lateinit var signInButtonText: String
-    private lateinit var signOutButtonText: String
     private lateinit var signedOutInfoText: String
-    private lateinit var deleteButtonText: String
     private lateinit var deleteInfoText: String
 
     @Before
@@ -57,25 +58,10 @@ open class LoginActivityTest {
 
         // Get the strings from the resources
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        deleteButtonText = context.resources.getString(
-            context.resources.getIdentifier(
-                "delete_account_button_text",
-                "string",
-                context.packageName
-            )
-        )
 
         deleteInfoText = context.resources.getString(
             context.resources.getIdentifier(
                 "account_deleted",
-                "string",
-                context.packageName
-            )
-        )
-
-        signOutButtonText = context.resources.getString(
-            context.resources.getIdentifier(
-                "sign_out_button_text",
                 "string",
                 context.packageName
             )
@@ -88,38 +74,22 @@ open class LoginActivityTest {
                 context.packageName
             )
         )
-
-        signInButtonText = context.resources.getString(
-            context.resources.getIdentifier(
-                "sign_in_button_text",
-                "string",
-                context.packageName
-            )
-        )
     }
 
     @Test
     fun signOutOfGoogleAccountResultsInCorrectMessage() {
-        val signOutButton = device.findObject(UiSelector().text(signOutButtonText))
+        val signOutButton = device.findObject(By.res(SIGN_OUT))
         signOutButton.click()
 
-        val confirmDialog: UiObject2 = device.wait(
-            Until.findObject(By.text(signedOutInfoText)), 5000
-        )
-
-        TestCase.assertNotNull(confirmDialog)
-        ViewMatchers.assertThat(confirmDialog.text, CoreMatchers.`is`(signedOutInfoText))
+        ViewMatchers.assertThat(device.findObject(By.res(INFO_TEXT)).text, CoreMatchers.`is`(signedOutInfoText))
     }
 
     @Test
     fun deleteGoogleAccountResultsInCorrectMessage() {
-        val deleteButton = device.findObject(UiSelector().text(deleteButtonText))
+        val deleteButton = device.findObject(By.res(DELETE_ACCOUNT))
         deleteButton.click()
-        val confirmDialog: UiObject2 = device.wait(
-            Until.findObject(By.text(deleteInfoText)), 5000
-        )
-        TestCase.assertNotNull(confirmDialog)
-        ViewMatchers.assertThat(confirmDialog.text, CoreMatchers.`is`(deleteInfoText))
+
+        ViewMatchers.assertThat(device.findObject(By.res(INFO_TEXT)).text, CoreMatchers.`is`(deleteInfoText))
     }
 
     //TODO implement this test

--- a/app/src/androidTest/java/com/github/sdpcoachme/SignupActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/SignupActivityTest.kt
@@ -12,6 +12,11 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.*
+import com.github.sdpcoachme.SignupActivity.TestTags.Buttons.Companion.SIGN_UP
+import com.github.sdpcoachme.SignupActivity.TestTags.TextFields.Companion.FIRST_NAME
+import com.github.sdpcoachme.SignupActivity.TestTags.TextFields.Companion.LAST_NAME
+import com.github.sdpcoachme.SignupActivity.TestTags.TextFields.Companion.LOCATION
+import com.github.sdpcoachme.SignupActivity.TestTags.TextFields.Companion.PHONE
 import com.github.sdpcoachme.data.UserInfo
 import junit.framework.TestCase
 import org.hamcrest.Matchers.allOf
@@ -40,15 +45,15 @@ open class SignupActivityTest {
                 "Jean", "Dupont",
                 email, "0692000000",
                 "Lausanne", listOf())
-            composeTestRule.onNodeWithTag("firstName").performTextInput(user.firstName)
+            composeTestRule.onNodeWithTag(FIRST_NAME).performTextInput(user.firstName)
             Espresso.closeSoftKeyboard()
-            composeTestRule.onNodeWithTag("lastName").performTextInput(user.lastName)
+            composeTestRule.onNodeWithTag(LAST_NAME).performTextInput(user.lastName)
             Espresso.closeSoftKeyboard()
-            composeTestRule.onNodeWithTag("phone").performTextInput(user.phone)
+            composeTestRule.onNodeWithTag(PHONE).performTextInput(user.phone)
             Espresso.closeSoftKeyboard()
-            composeTestRule.onNodeWithTag("location").performTextInput(user.location)
+            composeTestRule.onNodeWithTag(LOCATION).performTextInput(user.location)
             Espresso.closeSoftKeyboard()
-            composeTestRule.onNodeWithTag("registerButton").performClick()
+            composeTestRule.onNodeWithTag(SIGN_UP).performClick()
 
             // Important note: this get method was used instead of onTimeout due to onTiemout not
             // being found when running tests on Cirrus CI even with java version changed in build.gradle

--- a/app/src/main/java/com/github/sdpcoachme/DashboardActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/DashboardActivity.kt
@@ -23,6 +23,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.FAVORITES
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.HAMBURGER_MENU
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.HELP
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.LOGOUT
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.PROFILE
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.SCHEDULE
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.SETTINGS
+import com.github.sdpcoachme.DashboardActivity.TestTags.Companion.DASHBOARD_EMAIL
+import com.github.sdpcoachme.DashboardActivity.TestTags.Companion.DRAWER_HEADER
+import com.github.sdpcoachme.DashboardActivity.TestTags.Companion.MENU_LIST
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import kotlinx.coroutines.launch
 
@@ -32,7 +42,24 @@ import kotlinx.coroutines.launch
     above the main map view.
  */
 class DashboardActivity : ComponentActivity() {
-
+    class TestTags {
+        companion object {
+            const val DRAWER_HEADER = "drawerHeader"
+            const val DASHBOARD_EMAIL = "dashboardEmail"
+            const val MENU_LIST = "menuList"
+        }
+        class Buttons {
+            companion object {
+                const val HAMBURGER_MENU = "hamburgerMenu"
+                const val SCHEDULE = "schedule"
+                const val PROFILE = "profile"
+                const val FAVORITES = "favorites"
+                const val SETTINGS = "settings"
+                const val HELP = "help"
+                const val LOGOUT = "logout"
+            }
+        }
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // TODO handle the null better here
@@ -73,32 +100,32 @@ fun Dashboard(email: String, scaffoldState: ScaffoldState, onScaffoldStateChange
             DrawerHeader(email)
             DrawerBody(
                 items = listOf(
-                    MenuItem(id = "schedule", title = "Schedule",
+                    MenuItem(tag = SCHEDULE, title = "Schedule",
                         contentDescription = "See schedule",
                         icon = Icons.Default.CheckCircle),
-                    MenuItem(id = "profile", title = "Profile",
+                    MenuItem(tag = PROFILE, title = "Profile",
                         contentDescription = "Go to profile",
                         icon = Icons.Default.AccountCircle),
-                    MenuItem(id = "favorite", title = "Favorites",
+                    MenuItem(tag = FAVORITES, title = "Favorites",
                         contentDescription = "Go to favorites",
                         icon = Icons.Default.Favorite),
-                    MenuItem(id = "settings", title = "Settings",
+                    MenuItem(tag = SETTINGS, title = "Settings",
                         contentDescription = "Go to settings",
                         icon = Icons.Default.Settings),
-                    MenuItem(id = "help", title = "Help",
+                    MenuItem(tag = HELP, title = "Help",
                         contentDescription = "Get help",
                         icon = Icons.Default.Info),
-                MenuItem(id = "logout", title = "Log out",
+                MenuItem(tag = LOGOUT, title = "Log out",
                         contentDescription = "User logs out",
                         icon = Icons.Default.Close)),
                 onItemClick = {
-                    when (it.id) {
-                        "profile" -> {
+                    when (it.tag) {
+                        PROFILE -> {
                             val intent = Intent(context, EditProfileActivity::class.java)
                             intent.putExtra("email", email)
                             context.startActivity(intent)
                         }
-                        "logout" -> {
+                        LOGOUT -> {
                             (context.applicationContext as CoachMeApplication).authenticator.signOut(context) {
                                 val intent = Intent(context, LoginActivity::class.java)
                                 context.startActivity(intent)
@@ -130,7 +157,7 @@ fun AppBar(
         contentColor = MaterialTheme.colors.onPrimary,
         navigationIcon = {
             IconButton(
-                modifier = Modifier.testTag("appBarMenuIcon"),
+                modifier = Modifier.testTag(HAMBURGER_MENU),
                 onClick = onNavigationIconClick) {
                 Icon(
                     imageVector = Icons.Default.Menu,
@@ -147,12 +174,12 @@ fun DrawerHeader(email: String) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 40.dp)
-            .testTag("drawerHeader"),
+            .testTag(DRAWER_HEADER),
         contentAlignment = Alignment.Center,
         content = {
             Column(horizontalAlignment = CenterHorizontally) {
                 Text(text = "Dashboard", fontSize = 50.sp)
-                Text(modifier = Modifier.testTag("dashboardEmail"),
+                Text(modifier = Modifier.testTag(DASHBOARD_EMAIL),
                     text = email, fontSize = 20.sp)
             }
         }
@@ -165,13 +192,14 @@ fun DrawerBody(
     itemTextStyle: TextStyle = TextStyle(fontSize = 18.sp),
     onItemClick: (MenuItem) -> Unit
 ) {
-    LazyColumn(Modifier.testTag("menuList")) {
+    LazyColumn(Modifier.testTag(MENU_LIST)) {
         items(items) { item ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onItemClick(item) }
                     .padding(16.dp)
+                    .testTag(item.tag)
             ) {
                 Icon(
                     imageVector = item.icon,
@@ -187,7 +215,7 @@ fun DrawerBody(
 }
 
 data class MenuItem(
-    val id: String,
+    val tag: String,
     val title: String,
     val contentDescription: String,
     val icon: ImageVector

--- a/app/src/main/java/com/github/sdpcoachme/EditProfileActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/EditProfileActivity.kt
@@ -20,6 +20,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.EMAIL
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.FIRST_NAME
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.LAST_NAME
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_LABEL
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.firebase.database.Database
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
@@ -29,6 +34,36 @@ import java.util.concurrent.CompletableFuture
  * Activity used to view and edit the user's profile.
  */
 class EditProfileActivity : ComponentActivity() {
+
+    class TestTags {
+        class EditableProfileRowTag(tag: String) {
+            val FIELD = "${tag}TextField"
+            val TEXT = "${tag}Text"
+            val LABEL = "${tag}Label"
+            val ROW = "${tag}Row"
+        }
+        class UneditableProfileRowTag(tag: String) {
+            val TEXT = "${tag}Text"
+            val LABEL = "${tag}Label"
+            val ROW = "${tag}Row"
+        }
+        class Buttons {
+            companion object {
+                const val SAVE = "saveButton"
+                const val EDIT = "editButton"
+            }
+        }
+        companion object {
+            const val TITLE_ROW = "titleRow"
+            const val PROFILE_LABEL = "profileLabel"
+            const val PROFILE_PICTURE = "profilePicture"
+            const val PROFILE_COLUMN = "profileColumn"
+            val EMAIL = UneditableProfileRowTag("email")
+            val FIRST_NAME = EditableProfileRowTag("firstName")
+            val LAST_NAME = EditableProfileRowTag("lastName")
+            val SPORT = EditableProfileRowTag("sport")
+        }
+    }
 
     private lateinit var database: Database
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -93,18 +128,18 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .testTag("column"),
+            .testTag(EditProfileActivity.TestTags.PROFILE_COLUMN),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.Start
     ) {
         TitleRow()
         EmailRow(email)
 
-        ProfileRow(rowName = "First name", isEditing = isEditing, leftTextPadding = 45.dp,
+        ProfileRow(rowName = "First name", tag = FIRST_NAME, isEditing = isEditing, leftTextPadding = 45.dp,
             value = fname, onValueChange = { newValue -> fname = newValue })
-        ProfileRow(rowName = "Last name", isEditing = isEditing, leftTextPadding = 45.dp,
+        ProfileRow(rowName = "Last name", tag = LAST_NAME, isEditing = isEditing, leftTextPadding = 45.dp,
             value = lname, onValueChange = { newValue -> lname = newValue })
-        ProfileRow(rowName = "Favorite sport", isEditing = isEditing, leftTextPadding = 20.dp,
+        ProfileRow(rowName = "Favorite sport", tag = SPORT, isEditing = isEditing, leftTextPadding = 20.dp,
             value = favsport, onValueChange = { newValue -> favsport = newValue })
 
         if (isEditing) {
@@ -112,7 +147,7 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
             Button(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
-                    .testTag("save button"),
+                    .testTag(EditProfileActivity.TestTags.Buttons.SAVE),
                 onClick = {
                     isEditing = false
                     // TODO temporary sports handling
@@ -127,7 +162,7 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
             Button(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
-                    .testTag("edit button"),
+                    .testTag(EditProfileActivity.TestTags.Buttons.EDIT),
                 onClick = {
                     isEditing = true
                 }
@@ -146,11 +181,12 @@ fun TitleRow() {
     Row (
         modifier = Modifier
             .absolutePadding(20.dp, 20.dp, 0.dp, 10.dp)
-            .testTag("title row"),
+            .testTag(EditProfileActivity.TestTags.TITLE_ROW),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.Start
     ) {
         Text(
+            modifier = Modifier.testTag(PROFILE_LABEL),
             text = "My Profile",
             fontSize = 30.sp,
             fontWeight = FontWeight.Bold
@@ -167,7 +203,7 @@ fun TitleRow() {
                     .clip(CircleShape)
                     .border(2.dp, Color.Gray, CircleShape)
                     .absolutePadding(0.dp, 0.dp, 0.dp, 0.dp)
-                    .testTag("profile pic")
+                    .testTag(EditProfileActivity.TestTags.PROFILE_PICTURE)
             )
         }
     }
@@ -181,17 +217,17 @@ fun EmailRow(email: String) {
     Row (
         modifier = Modifier
             .absolutePadding(20.dp, 80.dp, 0.dp, 10.dp)
-            .testTag("email row"),
+            .testTag(EMAIL.ROW),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.Start
     ){
-        Text(text = "Email: ")
+        Text(modifier = Modifier.testTag(EMAIL.LABEL), text = "Email: ")
         // replace this Text with read-only TextField?
         Text(
             text = email,
             modifier = Modifier
                 .absolutePadding(80.dp, 0.dp, 0.dp, 0.dp)
-                .testTag("email address"),
+                .testTag(EMAIL.TEXT),
         )
     }
 }
@@ -206,22 +242,21 @@ fun EmailRow(email: String) {
  * @param onValueChange the function to call when the value of the row changes
  */
 @Composable
-fun ProfileRow(rowName: String, isEditing: Boolean, leftTextPadding: Dp, value: String, onValueChange: (String) -> Unit) {
-    val lowercaseRowName = rowName.lowercase()
+fun ProfileRow(rowName: String, tag: EditProfileActivity.TestTags.EditableProfileRowTag, isEditing: Boolean, leftTextPadding: Dp, value: String, onValueChange: (String) -> Unit) {
     Row(
         modifier = Modifier
             .absolutePadding(20.dp, 10.dp, 20.dp, 10.dp)
-            .testTag("$lowercaseRowName row"),
+            .testTag(tag.ROW),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.Start
     ) {
-        Text(text = "$rowName: ", modifier = Modifier.defaultMinSize(50.dp, 20.dp))
+        Text(text = "$rowName: ", modifier = Modifier.defaultMinSize(50.dp, 20.dp).testTag(tag.LABEL))
         if (isEditing) {
             TextField(
                 modifier = Modifier
                     .absolutePadding(leftTextPadding, 0.dp, 0.dp, 0.dp)
                     .defaultMinSize(150.dp, 40.dp)
-                    .testTag("editable $lowercaseRowName"),
+                    .testTag(tag.FIELD),
                 value = value,
                 onValueChange = { newValue -> onValueChange(newValue) },
                 singleLine = true,
@@ -230,7 +265,7 @@ fun ProfileRow(rowName: String, isEditing: Boolean, leftTextPadding: Dp, value: 
             Text(
                 modifier = Modifier
                     .absolutePadding(leftTextPadding + 6.dp, 0.dp, 0.dp, 0.dp)
-                    .testTag("saved $lowercaseRowName"),
+                    .testTag(tag.TEXT),
                 text = value)
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/SignupActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/SignupActivity.kt
@@ -19,6 +19,22 @@ import com.github.sdpcoachme.ui.theme.CoachMeTheme
 
 class SignupActivity : ComponentActivity() {
 
+    class TestTags {
+        class TextFields {
+            companion object {
+                const val FIRST_NAME = "firstName"
+                const val LAST_NAME = "lastName"
+                const val PHONE = "phone"
+                const val LOCATION = "location"
+            }
+        }
+        class Buttons {
+            companion object {
+                const val SIGN_UP = "signUpButton"
+            }
+        }
+    }
+
     private lateinit var database : Database
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -49,31 +65,31 @@ class SignupActivity : ComponentActivity() {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             TextField(
-                modifier = Modifier.testTag("firstName"),
+                modifier = Modifier.testTag(TestTags.TextFields.FIRST_NAME),
                 value = firstName,
                 onValueChange = { firstName = it },
                 label = { Text("First Name") }
             )
             TextField(
-                modifier = Modifier.testTag("lastName"),
+                modifier = Modifier.testTag(TestTags.TextFields.LAST_NAME),
                 value = lastName,
                 onValueChange = { lastName = it },
                 label = { Text("Last Name") }
             )
             TextField(
-                modifier = Modifier.testTag("phone"),
+                modifier = Modifier.testTag(TestTags.TextFields.PHONE),
                 value = phone,
                 onValueChange = { phone = it },
                 label = { Text("Phone") }
             )
             TextField(
-                modifier = Modifier.testTag("location"),
+                modifier = Modifier.testTag(TestTags.TextFields.LOCATION),
                 value = location,
                 onValueChange = { location = it },
                 label = { Text("Location") }
             )
             Button(
-                modifier = Modifier.testTag("registerButton"),
+                modifier = Modifier.testTag(TestTags.Buttons.SIGN_UP),
                 onClick = {
                     // Add the new user to the database
                     val newUser = UserInfo(


### PR DESCRIPTION
Each activity gets added a subclass called TestTags containing attributes for all the tags. Those tags are then imported in the test classes. A feature called testTagsAsResourceId is used to allow interoperability with UI Automator for LoginActivity class.

It seemed to be the most viable option that combined:
- Not wasting too much time declaring the tags (declaring them close to where they are used)
- Having some kind of compiler check as to whether the test tags exist or not
- Organizing the tags in a structured manner

There is no compile-time check for the declaration of the TestTags subclass, nor checks regarding its structure (it seems very hard to do such checks in Kotlin), but that was considered not enough of a downside to switch to other options such as declaring tags in a XML file and doing live parsing to recover the tags during tests, which are much less time efficient in my opinion.