### PR TITLE
Profile editing sports selection

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/EditProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/EditProfileActivityTest.kt
@@ -6,10 +6,13 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Buttons.Companion.EDIT
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Buttons.Companion.SAVE
+import com.github.sdpcoachme.EditProfileActivity.TestTags.Buttons.Companion.SELECT_SPORTS
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.CLIENT_COACH
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.COACH_CLIENT_INFO
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.EMAIL
@@ -17,7 +20,6 @@ import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.FIRST_NAME
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.LAST_NAME
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_LABEL
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_PICTURE
-//import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity
 import org.junit.Rule
@@ -39,6 +41,11 @@ class EditProfileActivityTest {
         SAVE
     )
 
+    private val defaultEmail = "example@email.com"
+    private val defaultIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
+        .putExtra("email", defaultEmail)
+
+
     @Test
     fun correctInitialScreenContent() {
         val initiallyDisplayed = listOf(
@@ -54,25 +61,18 @@ class EditProfileActivityTest {
             LAST_NAME.LABEL,
             LAST_NAME.TEXT,
 
-//            SPORT.LABEL,
-//            SPORT.TEXT,
-
             EDIT
         )
 
         val initiallyNotDisplayed = listOf(
             FIRST_NAME.FIELD,
             LAST_NAME.FIELD,
-//            SPORT.FIELD,
             CLIENT_COACH.SWITCH,
 
             SAVE
         )
 
-        val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
-        val email = "example@email.com"
-        editProfileIntent.putExtra("email", email)
-        ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
             initiallyDisplayed.forEach { tag ->
                 // assertIsDisplayed() behaves strangely with components that are empty (empty Text()
                 // components for example, or Text() components whose text is loaded asynchronously)
@@ -98,11 +98,7 @@ class EditProfileActivityTest {
 
     @Test
     fun editButtonClickActivatesCorrectElements() {
-
-        val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
-        val email = "example@email.com"
-        editProfileIntent.putExtra("email", email)
-        ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
             composeTestRule.onNodeWithTag(EDIT)
                 .assertIsDisplayed()
                 .performClick()
@@ -120,11 +116,7 @@ class EditProfileActivityTest {
             LAST_NAME to "Updated last name",
 //            SPORT to "Updated favorite sport"
         )
-
-        val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
-        val email = "example@email.com"
-        editProfileIntent.putExtra("email", email)
-        ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
             //change to edit mode
             composeTestRule.onNodeWithTag(EDIT)
                 .assertIsDisplayed()
@@ -154,14 +146,12 @@ class EditProfileActivityTest {
 
     @Test
     fun requestForExistingEmailDisplaysCorrectInfoInUserFields() {
-        val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
-        val email = "some@mail.com"
         val db = (InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as CoachMeApplication).database
         db.addUser(
                 UserInfo(
                     "first",
                     "last",
-                    email,
+                    defaultEmail,
                     "012345",
                     "Some Place",
                     false,
@@ -169,10 +159,9 @@ class EditProfileActivityTest {
                 )
             )
 
-        editProfileIntent.putExtra("email", email)
-        ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
 
-            composeTestRule.onNodeWithTag(EMAIL.TEXT).assertTextEquals(email)
+            composeTestRule.onNodeWithTag(EMAIL.TEXT).assertTextEquals(defaultEmail)
             composeTestRule.onNodeWithTag(FIRST_NAME.TEXT).assertTextEquals("first")
             composeTestRule.onNodeWithTag(LAST_NAME.TEXT).assertTextEquals("last")
             // TODO: add the other fields once they are implemented:
@@ -185,7 +174,7 @@ class EditProfileActivityTest {
                 composeTestRule.onNodeWithTag(tag).assertIsDisplayed()
             }
 
-            composeTestRule.onNodeWithTag(EMAIL.TEXT).assertTextEquals(email)
+            composeTestRule.onNodeWithTag(EMAIL.TEXT).assertTextEquals(defaultEmail)
             composeTestRule.onNodeWithTag(FIRST_NAME.FIELD).assertTextEquals("first")
             composeTestRule.onNodeWithTag(LAST_NAME.FIELD).assertTextEquals("last")
             // TODO: add the other fields once they are implemented:
@@ -221,10 +210,7 @@ class EditProfileActivityTest {
 
     @Test
     fun changingToCoachAndBackToClientWorks() {
-        val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)
-        val email = "example@email.com"
-        editProfileIntent.putExtra("email", email)
-        ActivityScenario.launch<EditProfileActivity>(editProfileIntent).use {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
 
             composeTestRule.onNodeWithTag(EDIT)
                 .assertIsDisplayed()
@@ -251,6 +237,47 @@ class EditProfileActivityTest {
 
             composeTestRule.onNodeWithTag(COACH_CLIENT_INFO).assertTextEquals("Coach")
             composeTestRule.onNodeWithTag(CLIENT_COACH.TEXT).assertTextEquals("I would like to become a client")
+        }
+    }
+    
+    @Test
+    fun selectSportsButtonRedirectsToSelectSportsActivity() {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
+            Intents.init()
+
+            composeTestRule.onNodeWithTag(SELECT_SPORTS)
+                .assertIsDisplayed()
+                .performClick()
+
+            Intents.intended(IntentMatchers.hasComponent(SelectSportsActivity::class.java.name))
+            Intents.release()
+        }
+    }
+
+    @Test
+    fun selectSportsButtonNotPresentInEditMode() {
+        ActivityScenario.launch<EditProfileActivity>(defaultIntent).use {
+            Intents.init()
+            composeTestRule.onNodeWithTag(SELECT_SPORTS)
+                .assertIsDisplayed()
+
+            composeTestRule.onNodeWithTag(EDIT)
+                .assertIsDisplayed()
+                .performClick()
+
+            composeTestRule.onNodeWithTag(SELECT_SPORTS)
+                .assertDoesNotExist()
+
+            composeTestRule.onNodeWithTag(SAVE)
+                .assertIsDisplayed()
+                .performClick()
+
+            composeTestRule.onNodeWithTag(SELECT_SPORTS)
+                .assertIsDisplayed()
+                .performClick()
+
+            Intents.intended(IntentMatchers.hasComponent(SelectSportsActivity::class.java.name))
+            Intents.release()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/sdpcoachme/EditProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/EditProfileActivityTest.kt
@@ -17,7 +17,7 @@ import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.FIRST_NAME
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.LAST_NAME
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_LABEL
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_PICTURE
-import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
+//import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity
 import org.junit.Rule
@@ -33,7 +33,7 @@ class EditProfileActivityTest {
     private val displayedAfterEditButtonClicked = listOf(
         FIRST_NAME.FIELD,
         LAST_NAME.FIELD,
-        SPORT.FIELD,
+//        SPORT.FIELD,
         CLIENT_COACH.SWITCH,
 
         SAVE
@@ -54,8 +54,8 @@ class EditProfileActivityTest {
             LAST_NAME.LABEL,
             LAST_NAME.TEXT,
 
-            SPORT.LABEL,
-            SPORT.TEXT,
+//            SPORT.LABEL,
+//            SPORT.TEXT,
 
             EDIT
         )
@@ -63,7 +63,7 @@ class EditProfileActivityTest {
         val initiallyNotDisplayed = listOf(
             FIRST_NAME.FIELD,
             LAST_NAME.FIELD,
-            SPORT.FIELD,
+//            SPORT.FIELD,
             CLIENT_COACH.SWITCH,
 
             SAVE
@@ -118,7 +118,7 @@ class EditProfileActivityTest {
         val newValues = mapOf(
             FIRST_NAME to "Updated first name",
             LAST_NAME to "Updated last name",
-            SPORT to "Updated favorite sport"
+//            SPORT to "Updated favorite sport"
         )
 
         val editProfileIntent = Intent(ApplicationProvider.getApplicationContext(), EditProfileActivity::class.java)

--- a/app/src/androidTest/java/com/github/sdpcoachme/SelectSportsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/SelectSportsActivityTest.kt
@@ -189,7 +189,6 @@ open class SelectSportsActivityTest {
 
     @Test
     fun errorPageIsShownAfterDBAddUserError() {
-        //errorPage is shown when no user corresponds to the email
         errorPageLaunchChecker("throw@Exception.com")
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/SelectSportsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/SelectSportsActivityTest.kt
@@ -134,17 +134,21 @@ open class SelectSportsActivityTest {
 
     @Test
     fun userInfoUpdatedWithAllSelectedSportsAndRedirectedToDashboardActivity() {
+        checkRedirectionAfterRegister(launchSignup, DashboardActivity::class.java.name)
+    }
+
+    @Test
+    fun redirectsToProfileActivityWhenIsEditingProfileIsTrue() {
+        checkRedirectionAfterRegister(launchSignup.putExtra("isEditingProfile", true), EditProfileActivity::class.java.name)
+    }
+
+    private fun checkRedirectionAfterRegister(launcher: Intent, intendedClass: String) {
         ActivityScenario.launch<SignupActivity>(launchSignup).use {
             Intents.init()
             val updatedUser =
                 database.addUser(userInfo)
                     .thenApply {
-                        val launchSignup = Intent(
-                            ApplicationProvider.getApplicationContext(),
-                            SelectSportsActivity::class.java
-                        )
-                        launchSignup.putExtra("email", email)
-                        ActivityScenario.launch<SignupActivity>(launchSignup).use {
+                        ActivityScenario.launch<SignupActivity>(launcher).use {
                             SelectSportsActivity.TestTags.MultiSelectListTag.ROW_TEXT_LIST.forEach {
                                 composeTestRule.onNodeWithTag(it.ROW).performClick()
                             }
@@ -159,7 +163,7 @@ open class SelectSportsActivityTest {
 
             Intents.intended(
                 allOf(
-                    IntentMatchers.hasComponent(DashboardActivity::class.java.name),
+                    IntentMatchers.hasComponent(intendedClass),
                     hasExtra("email", email)
                 )
             )

--- a/app/src/androidTest/java/com/github/sdpcoachme/firebase/database/MockDatabase.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/firebase/database/MockDatabase.kt
@@ -38,6 +38,11 @@ class MockDatabase: Database {
     }
 
     override fun getUser(email: String): CompletableFuture<UserInfo> {
+        if (email == "throwGet@Exception.com") {
+            val error = CompletableFuture<UserInfo>()
+            error.completeExceptionally(IllegalArgumentException("Simulated DB error"))
+            return error
+        }
         return getMap(accounts, email).thenApply { it as UserInfo }
 
     }

--- a/app/src/main/java/com/github/sdpcoachme/EditProfileActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/EditProfileActivity.kt
@@ -1,5 +1,6 @@
 package com.github.sdpcoachme
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -26,7 +27,7 @@ import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.EMAIL
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.FIRST_NAME
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.LAST_NAME
 import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.PROFILE_LABEL
-import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
+//import com.github.sdpcoachme.EditProfileActivity.TestTags.Companion.SPORT
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.firebase.database.Database
@@ -59,6 +60,7 @@ class EditProfileActivity : ComponentActivity() {
             companion object {
                 const val SAVE = "saveButton"
                 const val EDIT = "editButton"
+                const val SELECT_SPORTS = "selectSportsButton"
             }
         }
         companion object {
@@ -70,7 +72,7 @@ class EditProfileActivity : ComponentActivity() {
             val EMAIL = UneditableProfileRowTag("email")
             val FIRST_NAME = EditableProfileRowTag("firstName")
             val LAST_NAME = EditableProfileRowTag("lastName")
-            val SPORT = EditableProfileRowTag("sport")
+//            val SPORT = EditableProfileRowTag("sport")
             val CLIENT_COACH = SwitchClientCoachRowTag("clientCoach")
 
         }
@@ -108,15 +110,17 @@ class EditProfileActivity : ComponentActivity() {
  */
 @Composable
 fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
-    val database = (LocalContext.current.applicationContext as CoachMeApplication).database
+    val context = LocalContext.current
+    val database = (context.applicationContext as CoachMeApplication).database
 
     // bind those to database
     var isEditing by remember { mutableStateOf(false) }
     var fname by remember { mutableStateOf("") }
     var lname by remember { mutableStateOf("") }
-    var favsport by remember { mutableStateOf("") }
     var isCoach by remember { mutableStateOf(false) }
     var switchCoachClient by remember { mutableStateOf(false) }
+
+    var userInfo by remember { mutableStateOf(UserInfo()) }
 
     var f by remember { mutableStateOf(futureUserInfo)}
 
@@ -125,9 +129,9 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
             fname = newUser.firstName
             lname = newUser.lastName
             // TODO temporary sports handling
-            favsport = ""
             isCoach = newUser.coach
             f = CompletableFuture.completedFuture(null)
+            userInfo = newUser
         }
     }
 
@@ -145,8 +149,6 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
             value = fname, onValueChange = { newValue -> fname = newValue })
         ProfileRow(rowName = "Last name", tag = LAST_NAME, isEditing = isEditing, leftTextPadding = 45.dp,
             value = lname, onValueChange = { newValue -> lname = newValue })
-        ProfileRow(rowName = "Favorite sport", tag = SPORT, isEditing = isEditing, leftTextPadding = 20.dp,
-            value = favsport, onValueChange = { newValue -> favsport = newValue })
 
         if (isEditing) {
             SwitchClientCoachRow(isCoach, switchCoachClient) { switchCoachClient = it }
@@ -158,16 +160,29 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>) {
                     .testTag(EditProfileActivity.TestTags.Buttons.SAVE),
                 onClick = {
                     isEditing = false
-                    // TODO temporary sports handling
                     isCoach = isCoach xor switchCoachClient
                     switchCoachClient = false
-                    val newUser = UserInfo(fname, lname, email, "", "", isCoach, listOf())
+                    val newUser = UserInfo(fname, lname, email, "", "", isCoach, userInfo.sports)
                     database.addUser(newUser)
                 }
             ) {
                 Text(text = "Save changes")
             }
         } else {
+            Button(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .testTag(EditProfileActivity.TestTags.Buttons.SELECT_SPORTS),
+                onClick = {
+                    val selSportsIntent = Intent(context, SelectSportsActivity::class.java)
+                    selSportsIntent.putExtra("email", email)
+                    selSportsIntent.putExtra("isEditingProfile", true)
+                    context.startActivity(selSportsIntent)
+                }
+            ) {
+                Text(text = "Select sports")
+            }
+
             // edit button
             Button(
                 modifier = Modifier

--- a/app/src/main/java/com/github/sdpcoachme/SelectSportsActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/SelectSportsActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.data.ListItem
@@ -51,7 +52,6 @@ class SelectSportsActivity : ComponentActivity() {
         }
     }
 
-
     private lateinit var database : Database
     private lateinit var email: String
 
@@ -61,7 +61,7 @@ class SelectSportsActivity : ComponentActivity() {
         val emailReceived = intent.getStringExtra("email")
         val isEditingProfile = intent.getBooleanExtra("isEditingProfile", false)
         if (emailReceived == null) {
-            val errorMsg = "Profile editing did not receive an email address." +
+            val errorMsg = "Sports selecting did not receive an email address." +
                     "\n Please return to the login page and try again."
             ErrorHandlerLauncher().launchExtrasErrorHandler(this, errorMsg)
         } else {
@@ -77,6 +77,7 @@ class SelectSportsActivity : ComponentActivity() {
 
     @Composable
     fun FavoriteSportsSelection(isEditingProfile: Boolean, userFuture: CompletableFuture<UserInfo>) {
+        val context = LocalContext.current
         var sportItems by remember {
             mutableStateOf(Sports.values().map { ListItem(it, false) })
         }
@@ -129,22 +130,19 @@ class SelectSportsActivity : ComponentActivity() {
                             sports = sportItems.filter { it.selected }.map { it.element })
                         }
                         .thenApply { user -> database.addUser(user) }
-                        .handle { _, exception ->
-                            when (exception) {
-                                null -> {
-                                    val targetClass =
-                                        if (isEditingProfile) EditProfileActivity::class.java
-                                        else DashboardActivity::class.java
+                        .thenApply {
+                            val targetClass =
+                                if (isEditingProfile) EditProfileActivity::class.java
+                                else DashboardActivity::class.java
 
-                                    val intent = Intent(applicationContext, targetClass)
-                                    intent.putExtra("email", email)
-                                    startActivity(intent)
-                                }
-                                else -> {
-                                    ErrorHandlerLauncher().launchExtrasErrorHandler(
-                                        applicationContext, exception.toString())
-                                }
-                            }
+                            val intent = Intent(context, targetClass)
+                            intent.putExtra("email", email)
+                            startActivity(intent)
+                        }.exceptionally {
+                            println("inside the error handler $it")
+                            val errorMsg = "There was a database error.\nPlease return to the login page and try again."
+                            ErrorHandlerLauncher().launchExtrasErrorHandler(
+                                context, errorMsg)
                         }
                 }
             )
@@ -156,7 +154,8 @@ class SelectSportsActivity : ComponentActivity() {
     @Composable
     fun MultiSelectList(items: List<ListItem<Sports>>, toggleSelectSport: (Sports) -> Unit) {
         LazyColumn(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .testTag(TestTags.MultiSelectListTag.LAZY_SELECT_COLUMN)
         ) {
             items(items.size) { i ->


### PR DESCRIPTION
This pull request will enable the user to adapt the selection of favorite sports previously selected at sign-up. In the profile activity, the user now can select a button to edit their favorite sports. This button then takes them to the SelectSportsActivity. There, the previously selected favorite sports are preselected, so that the user sees what they have already selected (they can still deselect it if they like). After saving the choice, the user is redirected back to the profile activity.

Tests have also been added for this new functionality and to increase the previous test coverage.