### PR TITLE
Add front end to display list of coaches

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     //noinspection GradleDependency
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.3.1'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'com.google.firebase:firebase-database-ktx:20.1.0'

--- a/app/src/androidTest/java/com/github/sdpcoachme/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/CoachesListActivityTest.kt
@@ -1,0 +1,126 @@
+package com.github.sdpcoachme
+
+import android.content.Intent
+import android.os.SystemClock
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.sdpcoachme.data.Sports
+import com.github.sdpcoachme.data.UserInfo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CompletableFuture
+
+@RunWith(AndroidJUnit4::class)
+class CoachesListActivityTest {
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    @Test
+    fun allCoachesExists() {
+        // Populate the database
+        populateDatabase().thenRun {
+            // Launch the activity
+            val scheduleIntent = Intent(ApplicationProvider.getApplicationContext(), CoachesListActivity::class.java)
+            ActivityScenario.launch<ScheduleActivity>(scheduleIntent).use {
+                // Check that all coaches are displayed
+
+                // TODO: this is temporary ! We need to find a better way to wait for activities to fetch from the database
+                SystemClock.sleep(500)
+                coaches.forEach { coach ->
+                    composeTestRule.onNodeWithText("${coach.firstName} ${coach.lastName}").assertExists()
+                    composeTestRule.onNodeWithText(coach.location).assertExists()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun allNonCoachesDoNotExist() {
+        // Populate the database
+        populateDatabase().thenRun {
+            // Launch the activity
+            val scheduleIntent = Intent(ApplicationProvider.getApplicationContext(), CoachesListActivity::class.java)
+            ActivityScenario.launch<ScheduleActivity>(scheduleIntent).use {
+                // Check that all non coach users are not displayed
+
+                SystemClock.sleep(500)
+                coaches.forEach { coach ->
+                    composeTestRule.onNodeWithText("${coach.firstName} ${coach.lastName}").assertDoesNotExist()
+                    composeTestRule.onNodeWithText(coach.location).assertDoesNotExist()
+                }
+            }
+        }
+    }
+
+    // TODO: add tests to see whether clicking on a coach opens the correct activity
+
+    private val coaches = listOf(
+        UserInfo(
+            firstName = "John",
+            lastName = "Doe",
+            email = "john.doe@email.com",
+            location = "Paris",
+            phone = "0123456789",
+            sports = listOf(Sports.SKI, Sports.SWIMMING),
+            coach = true
+        ),
+        UserInfo(
+            firstName = "Marc",
+            lastName = "Delémont",
+            email = "marc@email.com",
+            location = "Lausanne",
+            phone = "0123456789",
+            sports = listOf(Sports.WORKOUT),
+            coach = true
+        ),
+        UserInfo(
+            firstName = "Kate",
+            lastName = "Senior",
+            email = "katy@email.com",
+            location = "Payerne",
+            phone = "0123456789",
+            sports = listOf(Sports.TENNIS, Sports.SWIMMING),
+            coach = true
+        )
+    )
+
+    private val nonCoaches = listOf(
+        UserInfo(
+            firstName = "James",
+            lastName = "Dolorian",
+            email = "jammy@email.com",
+            location = "Londres",
+            phone = "0123456789",
+            sports = listOf(Sports.SKI, Sports.SWIMMING),
+            coach = false
+        ),
+        UserInfo(
+            firstName = "Loris",
+            lastName = "Gotti",
+            email = "lolo@email.com",
+            location = "Corcelles",
+            phone = "0123456789",
+            sports = listOf(Sports.TENNIS),
+            coach = false
+        )
+    )
+
+    private fun populateDatabase(): CompletableFuture<Void> {
+        val database = (InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as CoachMeApplication).database
+
+        // Add a few coaches to the database
+        val futures1 = coaches.map { database.addUser(it) }
+
+        // Add non-coach user to the database
+        val futures2 = nonCoaches.map { database.addUser(it) }
+
+        return CompletableFuture.allOf(*futures1.toTypedArray(), *futures2.toTypedArray())
+    }
+
+}

--- a/app/src/androidTest/java/com/github/sdpcoachme/DashboardActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/DashboardActivityTest.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.COACHES_LIST
 import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.HAMBURGER_MENU
 import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.LOGOUT
 import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.PROFILE
@@ -191,6 +192,15 @@ class DashboardActivityTest {
             EXISTING_EMAIL,
             LOGOUT,
             hasComponent(LoginActivity::class.java.name)
+        )
+    }
+
+    @Test
+    fun dashboardCorrectlyRedirectsOnCoachesListClick() {
+        dashboardCorrectlyRedirectsOnMenuItemClick(
+            EXISTING_EMAIL,
+            COACHES_LIST,
+            hasComponent(CoachesListActivity::class.java.name)
         )
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/firebase/database/MockDatabase.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/firebase/database/MockDatabase.kt
@@ -21,6 +21,7 @@ class MockDatabase: Database {
         emptyList()
     )
 
+    // TODO: type any is not ideal, needs refactoring
     private val root = hashMapOf<String, Any>()
     private val accounts = hashMapOf<String, Any>(defaultEmail to defaultUserInfo)
 
@@ -49,6 +50,12 @@ class MockDatabase: Database {
         }
         return getMap(accounts, email).thenApply { it as UserInfo }
 
+    }
+
+    override fun getAllUsers(): CompletableFuture<List<UserInfo>> {
+        val future = CompletableFuture<List<UserInfo>>()
+        future.complete(accounts.values.map { it as UserInfo })
+        return future
     }
 
     override fun userExists(email: String): CompletableFuture<Boolean> {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".CoachMeApplication"
@@ -11,12 +11,17 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.CoachMe"
-        tools:targetApi="31" >
+        tools:targetApi="31">
+        <activity
+            android:name=".CoachesListActivity"
+            android:exported="false"
+            android:label="@string/title_activity_coaches_list"
+            android:theme="@style/Theme.CoachMe" />
         <activity
             android:name=".LoginActivity"
             android:exported="true"
             android:label="@string/title_activity_login"
-            android:theme="@style/Theme.CoachMe" >
+            android:theme="@style/Theme.CoachMe">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -52,8 +57,7 @@
             android:name=".SelectSportsActivity"
             android:exported="true"
             android:label="@string/title_activity_multiselect_list"
-            android:theme="@style/Theme.CoachMe" >
-        </activity>
+            android:theme="@style/Theme.CoachMe" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/sdpcoachme/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/CoachesListActivity.kt
@@ -23,9 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.github.sdpcoachme.data.Sports
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import java.util.concurrent.CompletableFuture
@@ -66,7 +64,7 @@ fun UserInfoListItem(user: UserInfo) {
             .clickable {
                 // TODO: open user profile in details
             }
-            .padding(16.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
             .height(100.dp)
             ,
         verticalAlignment = Alignment.CenterVertically
@@ -97,7 +95,9 @@ fun UserInfoListItem(user: UserInfo) {
                 Icon(
                     imageVector = Icons.Default.Place,
                     tint = Color.Gray,
-                    contentDescription = "${user.firstName} ${user.lastName}'s location")
+                    contentDescription = "${user.firstName} ${user.lastName}'s location",
+                    modifier = Modifier.size(20.dp)
+                )
                 Spacer(modifier = Modifier.width(4.dp))
                 // Temporary, until we implement proper location handling
                 Text(
@@ -115,7 +115,8 @@ fun UserInfoListItem(user: UserInfo) {
                     Icon(
                         imageVector = it.sportIcon,
                         tint = Color.Gray,
-                        contentDescription = it.sportName
+                        contentDescription = it.sportName,
+                        modifier = Modifier.size(20.dp)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                 }
@@ -123,27 +124,4 @@ fun UserInfoListItem(user: UserInfo) {
         }
     }
     Divider()
-}
-
-@Preview(showBackground = true)
-@Composable
-fun UserInfoListItemPreview() {
-    CoachMeTheme {
-        LazyColumn {
-            item {
-                UserInfoListItem(
-                    UserInfo(
-                        "John",
-                        "Doe",
-                        "placeholder",
-                        "placeholder",
-                        "Some very long address somewhere in the world which doesn't fit in this line",
-                        true,
-                        listOf(Sports.TENNIS, Sports.SKI, Sports.RUNNING),
-                        listOf()
-                    )
-                )
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/github/sdpcoachme/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/CoachesListActivity.kt
@@ -1,0 +1,149 @@
+package com.github.sdpcoachme
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.github.sdpcoachme.data.Sports
+import com.github.sdpcoachme.data.UserInfo
+import com.github.sdpcoachme.ui.theme.CoachMeTheme
+import java.util.concurrent.CompletableFuture
+
+class CoachesListActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val futureListOfCoaches = (application as CoachMeApplication).database
+            .getAllUsers().thenApply {
+                it.filter { user -> user.coach }
+            }
+        setContent {
+            var listOfCoaches by remember { mutableStateOf(listOf<UserInfo>()) }
+
+            // TODO: Need to handle the future correctly in cases like this (might need to use coroutines)
+            var f by remember { mutableStateOf(futureListOfCoaches) }
+            f.thenAccept {
+                listOfCoaches = it
+                f = CompletableFuture.completedFuture(null)
+            }
+
+            CoachMeTheme {
+                LazyColumn {
+                    items(listOfCoaches) { user ->
+                        UserInfoListItem(user)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun UserInfoListItem(user: UserInfo) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                // TODO: open user profile in details
+            }
+            .padding(16.dp)
+            .height(100.dp)
+            ,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // TODO: might be a good idea to merge the profile picture code used here and the one used in EditProfileActivity
+        Image(
+            painter = painterResource(id = R.drawable.ic_launcher_background),
+            contentDescription = "${user.firstName} ${user.lastName}'s profile picture",
+            modifier = Modifier
+                .size(80.dp)
+                .clip(CircleShape)
+                .border(2.dp, Color.Gray, CircleShape)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(
+            modifier = Modifier.fillMaxHeight(),
+            verticalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Text(
+                text = "${user.firstName} ${user.lastName}",
+                style = MaterialTheme.typography.h6,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Place,
+                    tint = Color.Gray,
+                    contentDescription = "${user.firstName} ${user.lastName}'s location")
+                Spacer(modifier = Modifier.width(4.dp))
+                // Temporary, until we implement proper location handling
+                Text(
+                    text = user.location,
+                    color = Color.Gray,
+                    style = MaterialTheme.typography.body2,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                user.sports.map {
+                    Icon(
+                        imageVector = it.sportIcon,
+                        tint = Color.Gray,
+                        contentDescription = it.sportName
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
+            }
+        }
+    }
+    Divider()
+}
+
+@Preview(showBackground = true)
+@Composable
+fun UserInfoListItemPreview() {
+    CoachMeTheme {
+        LazyColumn {
+            item {
+                UserInfoListItem(
+                    UserInfo(
+                        "John",
+                        "Doe",
+                        "placeholder",
+                        "placeholder",
+                        "Some very long address somewhere in the world which doesn't fit in this line",
+                        true,
+                        listOf(Sports.TENNIS, Sports.SKI, Sports.RUNNING),
+                        listOf()
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/sdpcoachme/DashboardActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/DashboardActivity.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.FAVORITES
+import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.COACHES_LIST
 import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.HAMBURGER_MENU
 import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.HELP
 import com.github.sdpcoachme.DashboardActivity.TestTags.Buttons.Companion.LOGOUT
@@ -54,7 +54,7 @@ class DashboardActivity : ComponentActivity() {
                 const val HAMBURGER_MENU = "hamburgerMenu"
                 const val SCHEDULE = "schedule"
                 const val PROFILE = "profile"
-                const val FAVORITES = "favorites"
+                const val COACHES_LIST = "coacheslist"
                 const val SETTINGS = "settings"
                 const val HELP = "help"
                 const val LOGOUT = "logout"
@@ -112,9 +112,9 @@ fun Dashboard(email: String, scaffoldState: ScaffoldState, onScaffoldStateChange
                     MenuItem(tag = PROFILE, title = "Profile",
                         contentDescription = "Go to profile",
                         icon = Icons.Default.AccountCircle),
-                    MenuItem(tag = FAVORITES, title = "Favorites",
-                        contentDescription = "Go to favorites",
-                        icon = Icons.Default.Favorite),
+                    MenuItem(tag = COACHES_LIST, title = "Nearby coaches",
+                        contentDescription = "See a list of coaches available close to you",
+                        icon = Icons.Default.People),
                     MenuItem(tag = SETTINGS, title = "Settings",
                         contentDescription = "Go to settings",
                         icon = Icons.Default.Settings),
@@ -140,6 +140,10 @@ fun Dashboard(email: String, scaffoldState: ScaffoldState, onScaffoldStateChange
                         SCHEDULE -> {
                             val intent = Intent(context, ScheduleActivity::class.java)
                             intent.putExtra("email", email)
+                            context.startActivity(intent)
+                        }
+                        COACHES_LIST -> {
+                            val intent = Intent(context, CoachesListActivity::class.java)
                             context.startActivity(intent)
                         }
                         else -> {

--- a/app/src/main/java/com/github/sdpcoachme/data/Sports.kt
+++ b/app/src/main/java/com/github/sdpcoachme/data/Sports.kt
@@ -1,9 +1,13 @@
 package com.github.sdpcoachme.data
 
-enum class Sports(val sportName: String) {
-    SKI("Ski"),
-    TENNIS("Tennis"),
-    RUNNING("Running"),
-    SWIMMING("Swimming"),
-    WORKOUT("Workout"),
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class Sports(val sportName: String, val sportIcon: ImageVector) {
+    SKI("Ski", Icons.Default.DownhillSkiing),
+    TENNIS("Tennis", Icons.Default.SportsTennis),
+    RUNNING("Running", Icons.Default.DirectionsRun),
+    SWIMMING("Swimming", Icons.Default.Pool),
+    WORKOUT("Workout", Icons.Default.FitnessCenter),
 }

--- a/app/src/main/java/com/github/sdpcoachme/firebase/database/Database.kt
+++ b/app/src/main/java/com/github/sdpcoachme/firebase/database/Database.kt
@@ -2,7 +2,6 @@ package com.github.sdpcoachme.firebase.database
 
 import com.github.sdpcoachme.data.Event
 import com.github.sdpcoachme.data.UserInfo
-import com.google.firebase.database.DatabaseReference
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -39,6 +38,12 @@ interface Database {
      * @return A future that will complete when the user has been gotten
      */
     fun getUser(email: String): CompletableFuture<UserInfo>
+
+    /**
+     * Get all users from the database
+     * @return A future that will complete with a list of all users in the database
+     */
+    fun getAllUsers(): CompletableFuture<List<UserInfo>>
 
     /**
      * Check if a user exists in the database

--- a/app/src/main/java/com/github/sdpcoachme/firebase/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/firebase/database/FireDatabase.kt
@@ -32,6 +32,17 @@ class FireDatabase(databaseReference: DatabaseReference) : Database {
         return getChild(accounts, userID).thenApply { it.getValue(UserInfo::class.java) }
     }
 
+    override fun getAllUsers(): CompletableFuture<List<UserInfo>> {
+        // TODO: might need refactoring to be more modular
+        val future = CompletableFuture<List<UserInfo>>()
+        accounts.get().addOnSuccessListener { snapshot ->
+            val users = snapshot.children.map { it.getValue(UserInfo::class.java)!! /* can't be null */ }
+            future.complete(users)
+        }.addOnFailureListener {
+            future.completeExceptionally(it)
+        }
+        return future
+    }
 
     override fun userExists(email: String): CompletableFuture<Boolean> {
         val userID = email.replace('.', ',')

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="sign_in_button_text">Sign in</string>
     <string name="sign_out_button_text">Sign out</string>
     <string name="delete_account_button_text">Delete Account</string>
+    <string name="title_activity_coaches_list">Nearby coaches</string>
 </resources>


### PR DESCRIPTION
This PR adds an activity that displays a list of nearby coaches.

As there were issues to handle locations using Google's [Places API](https://developers.google.com/maps/documentation/places/web-service/overview?hl=fr), the activity currently simply retrieves all coaches from the database and displays them in a vertical list. Each element of the list is clickable, and still needs to be hooked to send the proper intent to another activity that displays more information about a given coach.

Some TODOs were left where hacks / bad code practices were used. They will need to be refactored in the future.