### PR TITLE
Message coach button click from profile test

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/ProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/ProfileActivityTest.kt
@@ -26,7 +26,9 @@ import com.github.sdpcoachme.ProfileActivity.TestTags.Companion.SELECTED_SPORTS
 import com.github.sdpcoachme.location.UserLocationSamples.Companion.TOKYO
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity
+import com.github.sdpcoachme.messaging.ChatActivity
 import com.github.sdpcoachme.schedule.ScheduleActivity
+import org.hamcrest.CoreMatchers
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -279,8 +281,8 @@ class ProfileActivityTest {
         val displayedForUserLookingAtCoach = initiallyDisplayed.plus(MESSAGE_COACH)
 
         val profileIntent = Intent(ApplicationProvider.getApplicationContext(), ProfileActivity::class.java)
-        val email = "example@email.com"
-        profileIntent.putExtra("email", email)
+        val coachEmail = "example@email.com"
+        profileIntent.putExtra("email", coachEmail)
         profileIntent.putExtra("isViewingCoach", true)
         ActivityScenario.launch<ProfileActivity>(profileIntent).use {
             Intents.init()
@@ -292,7 +294,13 @@ class ProfileActivityTest {
                 .assertIsDisplayed()
                 .performClick()
 
-            // TODO: add check for the messaging activity once it is implemented
+            Intents.intended(
+                CoreMatchers.allOf(
+                    IntentMatchers.hasComponent(ChatActivity::class.java.name),
+                    IntentMatchers.hasExtra("toUserEmail", coachEmail)
+                )
+            )
+
             Intents.release()
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/ProfileActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ProfileActivity.kt
@@ -179,9 +179,6 @@ fun Profile(email: String, futureUserInfo: CompletableFuture<UserInfo>, isViewin
                     .align(Alignment.CenterHorizontally)
                     .testTag(ProfileActivity.TestTags.Buttons.MESSAGE_COACH),
                 onClick = {
-                    // For the moment, nothing happens
-                    // but in the future this could open the in app messenger with the coach
-                    //TODO: get own email!!!
                     val userEmail = database.getCurrentEmail()
                     val intent = Intent(context, ChatActivity::class.java)
                     intent.putExtra("currentUserEmail", userEmail)

--- a/app/src/main/java/com/github/sdpcoachme/firebase/database/CachingDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/firebase/database/CachingDatabase.kt
@@ -49,32 +49,32 @@ class CachingDatabase(private val wrappedDatabase: Database) : Database {
     }
 
     override fun getChatContacts(email: String): CompletableFuture<List<UserInfo>> {
-        // TODO implement
+        // TODO implement in next sprint
         return wrappedDatabase.getChatContacts(email)
     }
 
     override fun getChat(chatId: String): CompletableFuture<Chat> {
-        // TODO implement
+        // TODO implement in next sprint
         return wrappedDatabase.getChat(chatId)
     }
 
     override fun sendMessage(chatId: String, message: Message): CompletableFuture<Void> {
-        // TODO implement
+        // TODO implement in next sprint
         return wrappedDatabase.sendMessage(chatId, message)
     }
 
     override fun markMessagesAsRead(chatId: String, email: String): CompletableFuture<Void> {
-        // TODO implement
+        // TODO implement in next sprint
         return wrappedDatabase.markMessagesAsRead(chatId, email)
     }
 
     override fun addChatListener(chatId: String, onChange: (Chat) -> Unit) {
-        // TODO implement (adapt onChange to change this here and then call the passed onChange!)
+        // TODO implement in next sprint (adapt onChange to change this here and then call the passed onChange!)
         wrappedDatabase.addChatListener(chatId, onChange)
     }
 
     override fun removeChatListener(chatId: String) {
-        // TODO implement
+        // TODO implement in next sprint
         wrappedDatabase.removeChatListener(chatId)
     }
 


### PR DESCRIPTION
This small pull request completes a started test from the last sprint now that the in-app messaging has been implemented and refactors todos
- The test checks if the "message coach" button redirects the user to the ChatActivity. The corresponding todos have been removed.
- Also, this pr specifies that the added todos for the caching database should be implemented in the next sprint to enable caching for the messaging part of CoachMe.