### PR TITLE
Add markers on the map to see nearby coaches

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/CoachesListActivityTest.kt
@@ -65,9 +65,11 @@ open class CoachesListActivityTest {
         }
         */
         // Instead, make the test wait for the future to finish, and crash after a certain time
+        lateinit var stateLoading: CompletableFuture<Void>
         scenario.onActivity {
-            it.stateLoading.get(1000, MILLISECONDS)
+            stateLoading = it.stateLoading
         }
+        stateLoading.get(1000, MILLISECONDS)
     }
 
     // Necessary since we don't do scenario.use { ... } in each test, which closes automatically
@@ -154,9 +156,11 @@ open class CoachesListActivityTest {
             contactIntent.putExtra("isViewingContacts", true)
             scenario = ActivityScenario.launch(contactIntent)
 
+            lateinit var stateLoading: CompletableFuture<Void>
             scenario.onActivity {
-                it.stateLoading.get(1000, MILLISECONDS)
+                stateLoading = it.stateLoading
             }
+            stateLoading.get(1000, MILLISECONDS)
         }
 
         @Test

--- a/app/src/androidTest/java/com/github/sdpcoachme/firebase/database/MockDatabase.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/firebase/database/MockDatabase.kt
@@ -4,14 +4,17 @@ import com.github.sdpcoachme.data.Event
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.data.messaging.Chat
 import com.github.sdpcoachme.data.messaging.Message
-import java.time.LocalDateTime
 import com.github.sdpcoachme.location.UserLocationSamples.Companion.LAUSANNE
+import java.time.LocalDateTime
 import java.util.concurrent.CompletableFuture
 
 /**
  * A mock database class
  */
 class MockDatabase: Database {
+
+    // TODO: database should be empty by default, and tests should add data to it.
+    //  This way, we can make sure each test is independent from the others
 
     private val defaultEmail = "example@email.com"
     private val defaultUserInfo = UserInfo(

--- a/app/src/androidTest/java/com/github/sdpcoachme/map/MapActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/map/MapActivityTest.kt
@@ -35,6 +35,8 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class MapActivityTest {
 
+    // TODO add tests for markers
+
     private val random = LatLng(42.0,42.0)
 
     @get: Rule

--- a/app/src/androidTest/java/com/github/sdpcoachme/map/MapActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/map/MapActivityTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -18,11 +19,15 @@ import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.Dashboard.TestTags.Buttons.Companion.HAMBURGER_MENU
 import com.github.sdpcoachme.Dashboard.TestTags.Companion.BAR_TITLE
 import com.github.sdpcoachme.Dashboard.TestTags.Companion.DRAWER_HEADER
+import com.github.sdpcoachme.data.Sports
+import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.Buttons.Companion.GO_TO_LOGIN_BUTTON
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.TextFields.Companion.ERROR_MESSAGE_FIELD
+import com.github.sdpcoachme.location.UserLocationSamples
 import com.github.sdpcoachme.map.MapActivity.TestTags.Companion.MAP
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.google.android.gms.maps.model.LatLng
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -53,9 +58,72 @@ class MapActivityTest {
         Intent(ApplicationProvider.getApplicationContext(), MapActivity::class.java)
     private val EXISTING_EMAIL = "example@email.com"
 
+    private val coaches = listOf(
+        UserInfo(
+            firstName = "John",
+            lastName = "Doe",
+            email = "john.doe@email.com",
+            location = UserLocationSamples.PARIS,
+            phone = "0123456789",
+            sports = listOf(Sports.SKI, Sports.SWIMMING),
+            coach = true
+        ),
+        UserInfo(
+            firstName = "Marc",
+            lastName = "Delémont",
+            email = "marc@email.com",
+            location = UserLocationSamples.LAUSANNE,
+            phone = "0123456789",
+            sports = listOf(Sports.WORKOUT),
+            coach = true
+        ),
+        UserInfo(
+            firstName = "Kate",
+            lastName = "Senior",
+            email = "katy@email.com",
+            location = UserLocationSamples.LONDON,
+            phone = "0123456789",
+            sports = listOf(Sports.TENNIS, Sports.SWIMMING),
+            coach = true
+        )
+    )
+
+    private val nonCoaches = listOf(
+        UserInfo(
+            firstName = "James",
+            lastName = "Dolorian",
+            email = "jammy@email.com",
+            location = UserLocationSamples.TOKYO,
+            phone = "0123456789",
+            sports = listOf(Sports.SKI, Sports.SWIMMING),
+            coach = false
+        ),
+        UserInfo(
+            firstName = "Loris",
+            lastName = "Gotti",
+            email = "lolo@email.com",
+            location = UserLocationSamples.SYDNEY,
+            phone = "0123456789",
+            sports = listOf(Sports.TENNIS),
+            coach = false
+        )
+    )
+
     @Before
     fun setUp() {
         database.setCurrentEmail(EXISTING_EMAIL)
+        for (coach in coaches) {
+            database.updateUser(coach)
+        }
+        for (nonCoach in nonCoaches) {
+            database.updateUser(nonCoach)
+        }
+        Intents.init()
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
     }
 
     @SuppressLint("UnrememberedMutableState")
@@ -142,5 +210,65 @@ class MapActivityTest {
             composeTestRule.onNodeWithTag(mapTag).assertExists().assertIsDisplayed()
         }
     }
+
+    // TODO: for now, no tests are done on the markers in the map, since I could not find a way to
+    //  detect them in the composeTestRule. The testing code is left here for future reference, if
+    //  we ever decide to test the markers at some point.
+//    @Test
+//    fun mapCreatesCorrectMarkers() {
+//        ActivityScenario.launch<MapActivity>(defaultIntent).use {
+//            // Wait for activity to finish loading UI
+//            lateinit var markerLoading: CompletableFuture<Void>
+//            lateinit var mapLoading: CompletableFuture<Void>
+//            it.onActivity { activity ->
+//                markerLoading = activity.markerLoading
+//                mapLoading = activity.mapLoading
+//            }
+//            CompletableFuture.allOf(
+//                markerLoading,
+//                mapLoading
+//            ).get(3000, TimeUnit.MILLISECONDS)
+//
+//            // Check markers
+//            for (coach in coaches) {
+//                val markerTag = MARKER(coach)
+//                composeTestRule.onNodeWithTag(markerTag).assertExists().assertIsDisplayed()
+//            }
+//            for (nonCoach in nonCoaches) {
+//                val markerTag = MARKER(nonCoach)
+//                composeTestRule.onNodeWithTag(markerTag).assertDoesNotExist()
+//            }
+//        }
+//    }
+//
+//    @Test
+//    fun clickingOnMarkerOpensCoachProfile() {
+//        ActivityScenario.launch<MapActivity>(defaultIntent).use {
+//            // Wait for activity to finish loading UI
+//            lateinit var markerLoading: CompletableFuture<Void>
+//            lateinit var mapLoading: CompletableFuture<Void>
+//            it.onActivity { activity ->
+//                markerLoading = activity.markerLoading
+//                mapLoading = activity.mapLoading
+//            }
+//            CompletableFuture.allOf(
+//                markerLoading,
+//                mapLoading
+//            ).get(3000, TimeUnit.MILLISECONDS)
+//            val coach = coaches[0]
+//            val markerTag = MARKER(coach)
+//            val windowTag = MARKER_INFO_WINDOW(coach)
+//            composeTestRule.onNodeWithTag(markerTag).performClick()
+//            composeTestRule.onNodeWithTag(windowTag).assertExists().performClick()
+//            // Check that the ProfileActivity is launched with the correct extras
+//            Intents.intended(
+//                allOf(
+//                    hasComponent(ProfileActivity::class.java.name),
+//                    hasExtra("email", coach.email),
+//                    hasExtra("isViewingCoach", true)
+//                )
+//            )
+//        }
+//    }
 
 }

--- a/app/src/main/java/com/github/sdpcoachme/map/MapActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/map/MapActivity.kt
@@ -2,22 +2,35 @@ package com.github.sdpcoachme.map
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Place
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.Dashboard
+import com.github.sdpcoachme.ProfileActivity
+import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.firebase.database.Database
-import com.github.sdpcoachme.map.MapActivity.Companion.CAMPUS
 import com.github.sdpcoachme.map.MapActivity.TestTags.Companion.MAP
+import com.github.sdpcoachme.map.MapActivity.TestTags.Companion.MARKER
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -25,16 +38,21 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
+import kotlinx.coroutines.future.await
+import java.util.concurrent.CompletableFuture
 
 /**
  * Main map activity, launched after login. This activity contains the map view and holds
  * the current last known user location.
  */
 class MapActivity : ComponentActivity() {
+    // Allows to notice testing framework that the markers are displayed on the map
+    var markerLoading = CompletableFuture<Void>()
 
     class TestTags {
         companion object {
             const val MAP = "map"
+            fun MARKER(user: UserInfo) = "marker-${user.email}"
         }
     }
 
@@ -64,10 +82,19 @@ class MapActivity : ComponentActivity() {
             val errorMsg = "The map did not receive an email address.\nPlease return to the login page and try again."
             ErrorHandlerLauncher().launchExtrasErrorHandler(this, errorMsg)
         } else {
+            // For now, simply retrieve all users. We can decide later whether we want to have
+            // a dynamic list of markers that only displays nearby users (based on camera position
+            // for example). Since we have no way to download only the users that are nearby, we
+            // have to download all users anyways and filter them locally. This means that either
+            // way, we already have available all users locations, so we might as well display them
+            // all.
+            // Note: this is absolutely not scalable, but we can change this later on.
+            val futureUsers = database.getAllUsers().thenApply { users -> users.filter { it.coach } }
             setContent {
                 CoachMeTheme {
                     val dashboardContent: @Composable (Modifier) -> Unit = { modifier ->
-                        Map(modifier = modifier, lastUserLocation = lastUserLocation)
+                        Map(modifier = modifier, lastUserLocation = lastUserLocation,
+                            futureCoachesToDisplay = futureUsers, markerLoading = markerLoading)
                     }
                     Dashboard(dashboardContent, email)
                 }
@@ -116,7 +143,6 @@ class MapActivity : ComponentActivity() {
                             task.result.latitude,
                             task.result.longitude
                         )
-                        updateUserLocation()
                     } else {
                         println("Location is disabled on the device")
                         // TODO handle this case
@@ -127,14 +153,6 @@ class MapActivity : ComponentActivity() {
             error("getDeviceLocation was called without correct permissions : ${e.message}")
         }
     }
-
-    /**
-     * Updates the user location of the app. Needs to be called everytime we get a new device
-     * location : already called in getDeviceLocation for this purpose
-     */
-    private fun updateUserLocation() {
-        (application as CoachMeApplication).userLocation = lastUserLocation
-    }
 }
 
 /**
@@ -144,10 +162,25 @@ class MapActivity : ComponentActivity() {
  * location data. The MapState is updated by the MapViewModel in the DashboardActivity.
  */
 @Composable
-fun Map(modifier: Modifier, lastUserLocation: MutableState<LatLng?>) {
+fun Map(
+    modifier: Modifier,
+    lastUserLocation: MutableState<LatLng?>,
+    // Those 2 arguments have default values to avoid refactoring older tests
+    futureCoachesToDisplay: CompletableFuture<List<UserInfo>> = CompletableFuture.completedFuture(listOf()),
+    markerLoading: CompletableFuture<Void> = CompletableFuture<Void>()
+) {
+
+    val context = LocalContext.current
 
     val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(CAMPUS, 15f)
+        position = CameraPosition.fromLatLngZoom(MapActivity.CAMPUS, 15f)
+    }
+
+    var coachesToDisplay by remember { mutableStateOf(listOf<UserInfo>()) }
+    LaunchedEffect(true) {
+        coachesToDisplay = futureCoachesToDisplay.await()
+        // For testing purposes, we need to know when the map is ready
+        markerLoading.complete(null)
     }
 
     GoogleMap(
@@ -168,6 +201,74 @@ fun Map(modifier: Modifier, lastUserLocation: MutableState<LatLng?>) {
                 cameraPositionState.animate(
                     CameraUpdateFactory.newLatLngZoom(lastUserLocation.value!!, 17f)
                 )
+            }
+        }
+
+        coachesToDisplay.map { user ->
+            val state by remember {
+                mutableStateOf(
+                    MarkerState(LatLng(user.location.latitude, user.location.longitude))
+                )
+            }
+
+            MarkerInfoWindowContent(
+                state = state,
+                tag = MARKER(user),
+                onInfoWindowClick = {
+                    // TODO: code similar to CoachesList, might be able to modularize
+                    // Launches the ProfileActivity to display the coach's profile
+                    val displayCoachIntent = Intent(context, ProfileActivity::class.java)
+                    displayCoachIntent.putExtra("email", user.email)
+                    displayCoachIntent.putExtra("isViewingCoach", true)
+                    context.startActivity(displayCoachIntent)
+                }
+            ) {
+                // TODO: code similar to CoachesList, might be able to modularize
+                Column(
+                    modifier = Modifier
+                        .padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 12.dp)
+                        .fillMaxWidth(0.8f)
+                ) {
+                    Text(
+                        text = "${user.firstName} ${user.lastName}",
+                        style = MaterialTheme.typography.h6,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Place,
+                            tint = Color.Gray,
+                            contentDescription = "${user.firstName} ${user.lastName}'s location",
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(2.dp))
+                        Text(
+                            text = user.location.address,
+                            color = Color.Gray,
+                            style = MaterialTheme.typography.body2,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        user.sports.map {
+                            Icon(
+                                imageVector = it.sportIcon,
+                                tint = Color.Gray,
+                                contentDescription = it.sportName,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(modifier = Modifier.width(1.dp))
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds markers to the map that indicate where nearby coaches are located. For now, given the (very) small userbase of our app, we display all coaches on the map, but for better perfomance, we might decide later to only display coaches close to the camera position of the map, or close to the position of the user.

When clicking on a marker, a pop-up window opens showing quick information about the coach. One can then click on this window to open the full-page profile of the coach in a new activity.

After trying multiple times to test the existence of markers on the map without success (it seems they are not registered in compose' semantics node tree, but I couldn't figure out how to make them detectable in the tree), I decided to keep the testing code (tags, completablefuture for UI loading, ...) but to comment out the tests. That way, if we ever decide to test the markers, we can further investigate the issue without having to start from scratch.