### PR TITLE
Schedule addevents

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation 'com.google.maps.android:android-maps-utils:3.4.0'
     implementation 'androidx.activity:activity-compose:1.6.1'
     implementation 'com.maxkeppeler.sheets-compose-dialogs:core:1.0.2'
+    implementation 'com.maxkeppeler.sheets-compose-dialogs:color:1.0.2'
     implementation 'com.maxkeppeler.sheets-compose-dialogs:calendar:1.0.2'
     implementation 'com.maxkeppeler.sheets-compose-dialogs:clock:1.0.2'
     //noinspection GradleDependency

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.maps.android:android-maps-utils:3.4.0'
     implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation 'com.maxkeppeler.sheets-compose-dialogs:core:1.0.2'
+    implementation 'com.maxkeppeler.sheets-compose-dialogs:calendar:1.0.2'
+    implementation 'com.maxkeppeler.sheets-compose-dialogs:clock:1.0.2'
     //noinspection GradleDependency
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     //noinspection GradleDependency

--- a/app/src/androidTest/java/com/github/sdpcoachme/database/MockDatabase.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/database/MockDatabase.kt
@@ -99,14 +99,14 @@ open class MockDatabase: Database {
         return getMap(accounts, email).thenApply { it != null }
     }
 
-    override fun addEvents(events: List<Event>, currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
+    override fun addEvent(event: Event, currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
         if (currEmail == "throw@Exception.com") {
             val error = CompletableFuture<Schedule>()
             error.completeExceptionally(IllegalArgumentException("Simulated DB error"))
             return error
         }
         return getSchedule(currentWeekMonday).thenCompose { schedule ->
-            val newSchedule = schedule.copy(events = schedule.events + events)
+            val newSchedule = schedule.copy(events = schedule.events + event)
             schedules[currEmail] = newSchedule
             val future = CompletableFuture<Schedule>()
             future.complete(null)

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -25,12 +25,13 @@ import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.data.schedule.EventColors
 import com.github.sdpcoachme.database.Database
 import com.github.sdpcoachme.database.MockDatabase
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.CANCEL
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.COLOR_BOX
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_DATE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_TIME
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.SAVE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.START_DATE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.START_TIME
-import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.COLOR_BOX
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Companion.SCAFFOLD
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Icons.Companion.CANCEL_ICON
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Icons.Companion.SAVE_ICON
@@ -54,7 +55,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalTime
 
 @RunWith(AndroidJUnit4::class)
 class CreateEventActivityTest {
@@ -152,6 +152,16 @@ class CreateEventActivityTest {
     }
 
     @Test
+    fun cancelAddEventCorrectlyRedirectsToSchedule() {
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            composeTestRule.onNodeWithTag(CANCEL)
+                .performClick()
+
+            intended(hasComponent(ScheduleActivity::class.java.name))
+        }
+    }
+
+    @Test
     fun addEventSavesToDatabase() {
         ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
             composeTestRule.onNodeWithTag(EVENT_NAME)
@@ -178,7 +188,7 @@ class CreateEventActivityTest {
         }
     }
 
-    // TODO: Pressing the cancel button on the date picker works, but pressing the ok button does not
+    // Note: Pressing the cancel button on the date picker works, but pressing the ok button does not
     private fun cancelAndSavePickedDate(
         dateTag: String,
         dialogTitleTag: String,
@@ -236,7 +246,7 @@ class CreateEventActivityTest {
         }
     }
 
-    // TODO: Pressing the cancel button on the time picker works, but pressing the ok button does not
+    // Note: Pressing the cancel button on the time picker works, but pressing the ok button does not
     private fun cancelAndSavePickedTime(
         timeTag: String,
         dialogTitleTag: String,
@@ -246,7 +256,6 @@ class CreateEventActivityTest {
         val testHour2 = 5
         val testMinute1 = 3
         val testMinute2 = 0
-        val expectedTime = LocalTime.of("$testHour1$testHour2".toInt(), "$testMinute1$testMinute2".toInt())
 
         // Open time picker
         composeTestRule.onNodeWithTag(timeTag)
@@ -316,9 +325,8 @@ class CreateEventActivityTest {
         }
     }
 
-    // TODO: Check this test
     @Test
-    fun cancelAndConfirmColorWorks() {
+    fun chooseAndCancelColorPickerWorks() {
         ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
             val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -1,0 +1,172 @@
+package com.github.sdpcoachme.schedule
+
+import android.content.Intent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.sdpcoachme.CoachMeApplication
+import com.github.sdpcoachme.data.schedule.Event
+import com.github.sdpcoachme.data.schedule.EventColors
+import com.github.sdpcoachme.database.Database
+import com.github.sdpcoachme.database.MockDatabase
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_DATE
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_TIME
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.SAVE
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.START_DATE
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.START_TIME
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Companion.COLOR_BOX
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Companion.SCAFFOLD
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Icons.Companion.CANCEL_ICON
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Icons.Companion.SAVE_ICON
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.TextFields.Companion.DESCRIPTION
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.TextFields.Companion.EVENT_NAME
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.ACTIVITY_TITLE
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.COLOR_TEXT
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.END_DATE_TEXT
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.END_TIME_TEXT
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.START_DATE_TEXT
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.START_TIME_TEXT
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreateEventActivityTest {
+    private lateinit var database: Database
+    private val defaultEmail = "example@email.com"
+    private val defaultIntent = Intent(ApplicationProvider.getApplicationContext(), CreateEventActivity::class.java)
+
+    private val currentWeekMonday = EventOps.getStartMonday()
+    private val defaultEventName = "Test Event"
+    private val defaultEventStart = EventOps.getDefaultEventStart()
+    private val defaultEventEnd = EventOps.getDefaultEventEnd()
+    private val defaultEventDescription = "Test Description"
+
+    private val eventDateFormatter = EventOps.getEventDateFormatter()
+
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    @Before
+    fun setup() {
+        database = (InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as CoachMeApplication).database
+        database.setCurrentEmail(defaultEmail)
+        Intents.init()
+    }
+
+    @After
+    fun teardown() {
+        database.setCurrentEmail("")
+        if (database is MockDatabase) {
+            (database as MockDatabase).restoreDefaultSchedulesSetup()
+            println("MockDatabase was torn down")
+        }
+        Intents.release()
+    }
+
+    @Test
+    fun correctInitialScreenContent() {
+        val initiallyDisplayed = listOf(
+            SCAFFOLD,
+            ACTIVITY_TITLE,
+            CANCEL_ICON,
+            SAVE_ICON,
+            EVENT_NAME,
+            START_DATE_TEXT,
+            START_TIME_TEXT,
+            END_DATE_TEXT,
+            END_TIME_TEXT,
+            START_DATE,
+            START_TIME,
+            END_DATE,
+            END_TIME,
+            COLOR_TEXT,
+            COLOR_BOX,
+            DESCRIPTION,
+        )
+
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            initiallyDisplayed.forEach { tag ->
+                composeTestRule.onNodeWithTag(tag, useUnmergedTree = true).assertExists()
+                composeTestRule.onNodeWithTag(tag, useUnmergedTree = true).assertIsDisplayed()
+            }
+        }
+    }
+
+    private fun fillAndCheckFocus(text: String, tag: String) {
+        composeTestRule.onNodeWithTag(tag)
+            .assertIsNotFocused()
+        composeTestRule.onNodeWithTag(tag)
+            .performClick()
+        composeTestRule.onNodeWithTag(tag)
+            .assertIsFocused()
+        composeTestRule.onNodeWithTag(tag)
+            .performTextInput(text)
+        composeTestRule.onNodeWithTag(tag)
+            .performImeAction()
+        composeTestRule.onNodeWithTag(tag)
+            .assertIsNotFocused()
+    }
+
+    @Test
+    fun addEventWithCustomNameAndDescriptionRedirectsToSchedule() {
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            fillAndCheckFocus(defaultEventName, EVENT_NAME)
+            fillAndCheckFocus(defaultEventDescription, DESCRIPTION)
+
+            composeTestRule.onNodeWithTag(SAVE)
+                .assertExists()
+            composeTestRule.onNodeWithTag(SAVE)
+                .performClick()
+
+            intended(hasComponent(ScheduleActivity::class.java.name))
+        }
+    }
+
+    @Test
+    fun addEventSavesToDatabase() {
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            composeTestRule.onNodeWithTag(EVENT_NAME)
+                .performTextInput(defaultEventName)
+            composeTestRule.onNodeWithTag(DESCRIPTION)
+                .performTextInput(defaultEventDescription)
+            composeTestRule.onNodeWithTag(SAVE)
+                .performClick()
+
+            val expectedEvent = Event(
+                defaultEventName,
+                defaultEventStart.format(eventDateFormatter),
+                defaultEventEnd.format(eventDateFormatter),
+                defaultEventDescription,
+                EventColors.DEFAULT.color.value.toString()
+            )
+
+            database.getSchedule(currentWeekMonday).thenAccept {
+                val actualEvents = it.events
+
+                assertThat(actualEvents.size, `is`(1))
+                assertThat(actualEvents[0], `is`(expectedEvent))
+            }
+        }
+    }
+
+
+}
+

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -82,6 +82,7 @@ class CreateEventActivityTest {
 
     @After
     fun teardown() {
+        EventOps.clearMultiDayEventMap()
         database.setCurrentEmail("")
         if (database is MockDatabase) {
             (database as MockDatabase).restoreDefaultSchedulesSetup()

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
@@ -25,6 +26,7 @@ import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.data.schedule.EventColors
 import com.github.sdpcoachme.database.Database
 import com.github.sdpcoachme.database.MockDatabase
+import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.CANCEL
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.COLOR_BOX
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_DATE
@@ -134,6 +136,20 @@ class CreateEventActivityTest {
             .performImeAction()
         composeTestRule.onNodeWithTag(tag)
             .assertIsNotFocused()
+    }
+
+    @Test
+    fun addEventWithEmptyEmailRedirectsToErrorPage() {
+        database.setCurrentEmail("")
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            composeTestRule.onNodeWithTag(IntentExtrasErrorHandlerActivity.TestTags.Buttons.GO_TO_LOGIN_BUTTON)
+                .assertIsDisplayed()
+            composeTestRule.onNodeWithTag(IntentExtrasErrorHandlerActivity.TestTags.TextFields.ERROR_MESSAGE_FIELD)
+                .assertIsDisplayed()
+
+            composeTestRule.onNodeWithText("New event did not receive an email address.\n Please return to the login page and try again.")
+                .assertIsDisplayed()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -1,14 +1,17 @@
 package com.github.sdpcoachme.schedule
 
 import android.content.Intent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
@@ -36,6 +39,7 @@ import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Compani
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.COLOR_TEXT
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.END_DATE_TEXT
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.END_TIME_TEXT
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.START_DATE_DIALOG_TITLE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.START_DATE_TEXT
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.START_TIME_TEXT
 import org.hamcrest.MatcherAssert.assertThat
@@ -164,6 +168,21 @@ class CreateEventActivityTest {
                 assertThat(actualEvents.size, `is`(1))
                 assertThat(actualEvents[0], `is`(expectedEvent))
             }
+        }
+    }
+
+    @Test
+    fun clickingOnDateOpensDateDialog() {
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            composeTestRule.onNodeWithTag(START_DATE)
+                .performClick()
+
+            composeTestRule.onNodeWithTag(START_DATE_DIALOG_TITLE, useUnmergedTree = true)
+                .assertExists()
+
+            val pointOutsideDialog = Offset(-20f, -20f)
+            composeTestRule.onNodeWithTag(START_DATE_DIALOG_TITLE, useUnmergedTree = true)
+                .performTouchInput { click(position = pointOutsideDialog) }
         }
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -30,13 +30,14 @@ import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Co
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.SAVE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.START_DATE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.START_TIME
-import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Companion.COLOR_BOX
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.COLOR_BOX
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Companion.SCAFFOLD
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Icons.Companion.CANCEL_ICON
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Icons.Companion.SAVE_ICON
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.TextFields.Companion.DESCRIPTION
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.TextFields.Companion.EVENT_NAME
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.ACTIVITY_TITLE
+import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.COLOR_DIALOG_TITLE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.COLOR_TEXT
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.END_DATE_DIALOG_TITLE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Texts.Companion.END_DATE_TEXT
@@ -312,6 +313,27 @@ class CreateEventActivityTest {
     fun cancelAndConfirmEndTimeWorks() {
         ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
             cancelAndSavePickedTime(END_TIME, END_TIME_DIALOG_TITLE)
+        }
+    }
+
+    // TODO: Check this test
+    @Test
+    fun cancelAndConfirmColorWorks() {
+        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
+            val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+            // Open color picker
+            composeTestRule.onNodeWithTag(COLOR_BOX)
+                .performClick()
+            composeTestRule.onNodeWithTag(COLOR_DIALOG_TITLE, useUnmergedTree = true)
+                .assertExists()
+
+            // Press cancel
+            device.findObject(By.text("Cancel")).click()
+            device.wait(Until.gone(By.text("Cancel")), 500)
+
+            composeTestRule.onNodeWithTag(COLOR_DIALOG_TITLE)
+                .assertDoesNotExist()
         }
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/EventOpsTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/EventOpsTest.kt
@@ -1,9 +1,14 @@
 package com.github.sdpcoachme.schedule
 
 import androidx.compose.ui.graphics.Color
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.data.schedule.ShownEvent
+import com.github.sdpcoachme.database.Database
 import junit.framework.TestCase
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -18,8 +23,7 @@ class EventOpsTest {
      */
     companion object {
         private val currentMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-        private val nextMonday = currentMonday.plusDays(7)
-        val eventList = listOf(
+        val oneDayEvents = listOf(
             Event(
                 name = "Google I/O Keynote",
                 color = Color(0xFFAFBBF2).value.toString(),
@@ -41,28 +45,37 @@ class EventOpsTest {
                 end = currentMonday.plusDays(2).atTime(12, 0, 0).toString(),
                 description = "In this Keynote, Chet Haase, Dan Sandler, and Romain Guy discuss the latest Android features and enhancements for developers.",
             ),
-            Event(
-                name = "What's new in Machine Learning",
-                color = Color(0xFFF4BFDB).value.toString(),
-                start = currentMonday.plusDays(2).atTime(22, 0, 0).toString(),
-                end = currentMonday.plusDays(3).atTime(4, 0, 0).toString(),
-                description = "Learn about the latest and greatest in ML from Google. We’ll cover what’s available to developers when it comes to creating, understanding, and deploying models for a variety of different applications.",
-            ),
-            Event(
-                name = "What's new in Material Design",
-                color = Color(0xFF6DD3CE).value.toString(),
-                start = currentMonday.plusDays(3).atTime(13, 0, 0).toString(),
-                end = currentMonday.plusDays(3).atTime(15, 0, 0).toString(),
-                description = "Learn about the latest design improvements to help you build personal dynamic experiences with Material Design.",
-            ),
-            Event(
-                name = "Jetpack Compose Basics",
-                color = Color(0xFF1B998B).value.toString(),
-                start = nextMonday.plusDays(4).atTime(9, 0, 0).toString(),
-                end = nextMonday.plusDays(4).atTime(13, 0, 0).toString(),
-                description = "This Workshop will take you through the basics of building your first app with Jetpack Compose, Android's new modern UI toolkit that simplifies and accelerates UI development on Android.",
-            ),
         )
+        val multiDayEvent = Event(
+            name = "What's new in Machine Learning",
+            color = Color(0xFFF4BFDB).value.toString(),
+            start = currentMonday.plusDays(2).atTime(22, 0, 0).toString(),
+            end = currentMonday.plusDays(3).atTime(4, 0, 0).toString(),
+            description = "Learn about the latest and greatest in ML from Google. We’ll cover what’s available to developers when it comes to creating, understanding, and deploying models for a variety of different applications.",
+        )
+        val multiWeekEvent = Event(
+            name = "What's new in Material Design",
+            color = Color(0xFF6DD3CE).value.toString(),
+            start = currentMonday.plusDays(3).atTime(13, 0, 0).toString(),
+            end = currentMonday.plusWeeks(1).atTime(15, 0, 0).toString(),
+            description = "Learn about the latest design improvements to help you build personal dynamic experiences with Material Design."
+        )
+
+        val eventList = oneDayEvents + multiDayEvent + multiWeekEvent
+    }
+
+    private lateinit var database: Database
+    private val defaultEmail = "example@email.com"
+
+    @Before
+    fun setUp() {
+        database = (InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as CoachMeApplication).database
+        database.setCurrentEmail(defaultEmail)
+    }
+
+    @After
+    fun clearMultiDayEventMap() {
+        EventOps.clearMultiDayEventMap()
     }
 
     @Test
@@ -92,6 +105,52 @@ class EventOpsTest {
                 expectedMap[event] = shownEvents
             }
         }
-        TestCase.assertEquals(expectedMap, actualMap)
+
+        for (event in expectedMap.keys) {
+            for (shownEvent in expectedMap[event]!!) {
+                TestCase.assertTrue(actualMap.containsKey(event))
+                TestCase.assertTrue(actualMap[event]!!.contains(shownEvent))
+            }
+        }
+
+        TestCase.assertEquals(expectedMap.size, actualMap.size)
+    }
+
+    @Test
+    fun addEventUpdatesMultiDayEventMap() {
+        EventOps.addEvent(multiDayEvent, database).thenRun {
+            val actualMap = EventOps.getMultiDayEventMap()
+            val expectedMap = mutableMapOf<Event, List<ShownEvent>>()
+
+            val shownEvents = mutableListOf<ShownEvent>()
+            val start = LocalDateTime.parse(multiDayEvent.start)
+            val end = LocalDateTime.parse(multiDayEvent.end)
+            val daysBetween = ChronoUnit.DAYS.between(start.toLocalDate(), end.toLocalDate()).toInt()
+            if (daysBetween >= 1) {
+                for (i in 0..daysBetween) {
+                    val shownEvent = ShownEvent(
+                        name = multiDayEvent.name,
+                        color = multiDayEvent.color,
+                        start = if (i == 0) multiDayEvent.start else start.plusDays(i.toLong()).withHour(0).withMinute(0).withSecond(0).toString(),
+                        startText = multiDayEvent.start,
+                        end = if (i == daysBetween) multiDayEvent.end else start.plusDays(i.toLong()).withHour(23).withMinute(59).withSecond(59).toString(),
+                        endText = multiDayEvent.end,
+                        description = multiDayEvent.description,
+                    )
+                    shownEvents.add(shownEvent)
+                }
+                expectedMap[multiDayEvent] = shownEvents
+            }
+            TestCase.assertEquals(expectedMap, actualMap)
+        }
+    }
+
+    @Test
+    fun addEventDoesNotUpdateMultiDayEventMapForOnedayEvents() {
+        EventOps.addEvent(oneDayEvents[0], database).thenRun {
+            val actualMap = EventOps.getMultiDayEventMap()
+            val expectedMap = mutableMapOf<Event, List<ShownEvent>>()
+            TestCase.assertEquals(expectedMap, actualMap)
+        }
     }
 }

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/ScheduleActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/ScheduleActivityTest.kt
@@ -136,7 +136,13 @@ class ScheduleActivityTest {
     @Test
     fun eventsOfCurrentWeekAreDisplayedCorrectly() {
         database.setCurrentEmail(defaultEmail)
-        database.addEvents(eventList, currentMonday).thenRun {
+        database.addEvent(eventList[0], currentMonday).thenCompose {
+            database.addEvent(eventList[1], currentMonday)
+        }.thenCompose {
+            database.addEvent(eventList[2], currentMonday)
+        }.thenCompose {
+            database.addEvent(eventList[3], currentMonday)
+        }.thenRun {
             ActivityScenario.launch<ScheduleActivity>(defaultIntent).use {
                 composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()
                 val schedule = database.getSchedule(currentMonday)
@@ -159,7 +165,7 @@ class ScheduleActivityTest {
             end = currentMonday.plusDays(2).atTime(15, 0, 0).toString(),
             description = "This is a multi day event.",
         )
-        database.addEvents(listOf(multiDayEvent), currentMonday).thenRun {
+        database.addEvent(multiDayEvent, currentMonday).thenRun {
             ActivityScenario.launch<ScheduleActivity>(defaultIntent).use {
                 composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()
 
@@ -211,7 +217,7 @@ class ScheduleActivityTest {
             end = nextMonday.plusDays(1).atTime(15, 0, 0).toString(),
             description = "This is a multi week event.",
         )
-        database.addEvents(listOf(multiWeekEvent), currentMonday).thenRun {
+        database.addEvent(multiWeekEvent, currentMonday).thenRun {
             ActivityScenario.launch<ScheduleActivity>(defaultIntent).use {
                 composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()
 
@@ -278,7 +284,7 @@ class ScheduleActivityTest {
             end = nextMonday.atTime(15, 0, 0).toString(),
             description = "This is an event of the next week.",
         )
-        database.addEvents(listOf(nextWeekEvent), currentMonday).thenRun {
+        database.addEvent(nextWeekEvent, currentMonday).thenRun {
             database.setCurrentEmail(defaultEmail)
             ActivityScenario.launch<ScheduleActivity>(defaultIntent).use {
                 composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()
@@ -314,7 +320,7 @@ class ScheduleActivityTest {
             end = previousMonday.atTime(15, 0, 0).toString(),
             description = "This is an event of the previous week.",
         )
-        database.addEvents(listOf(previousWeekEvent), currentMonday).thenRun {
+        database.addEvent(previousWeekEvent, currentMonday).thenRun {
             database.setCurrentEmail(defaultEmail)
             ActivityScenario.launch<ScheduleActivity>(defaultIntent).use {
                 composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/ScheduleActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/ScheduleActivityTest.kt
@@ -88,6 +88,7 @@ class ScheduleActivityTest {
 
     @After
     fun teardown() {
+        EventOps.clearMultiDayEventMap()
         database.setCurrentEmail("")
         if (database is MockDatabase) {
             (database as MockDatabase).restoreDefaultSchedulesSetup()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,11 @@
             android:label="@string/title_activity_schedule"
             android:theme="@style/Theme.CoachMe" />
         <activity
+            android:name=".schedule.CreateEventActivity"
+            android:exported="false"
+            android:label="@string/title_activity_create_event"
+            android:theme="@style/Theme.CoachMe" />
+        <activity
             android:name=".profile.ProfileActivity"
             android:exported="false"
             android:label="@string/title_activity_edit_profile"

--- a/app/src/main/java/com/github/sdpcoachme/data/schedule/EventColors.kt
+++ b/app/src/main/java/com/github/sdpcoachme/data/schedule/EventColors.kt
@@ -11,5 +11,6 @@ enum class EventColors(val color: Color) {
     DARK_GREEN(Color(0xFF83AF83)),
     BLUE(Color(0xFF6290D5)),
     LIGHT_BLUE(Color(0xFF7AC2DC)),
-    PURPLE(Color(0xFFBF92E2))
+    PURPLE(Color(0xFFBF92E2)),
+    DEFAULT(RED.color)
 }

--- a/app/src/main/java/com/github/sdpcoachme/data/schedule/EventColors.kt
+++ b/app/src/main/java/com/github/sdpcoachme/data/schedule/EventColors.kt
@@ -1,0 +1,15 @@
+package com.github.sdpcoachme.data.schedule
+
+import androidx.compose.ui.graphics.Color
+
+enum class EventColors(val color: Color) {
+    RED(Color(0xFFD56767)),
+    SALMON(Color(0xFFE79484)),
+    ORANGE(Color(0xFFDF9E5D)),
+    LIME(Color(0xFFA4DC7A)),
+    MINT(Color(0xFF7ADCC0)),
+    DARK_GREEN(Color(0xFF83AF83)),
+    BLUE(Color(0xFF6290D5)),
+    LIGHT_BLUE(Color(0xFF7AC2DC)),
+    PURPLE(Color(0xFFBF92E2))
+}

--- a/app/src/main/java/com/github/sdpcoachme/database/CachingDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/CachingDatabase.kt
@@ -74,7 +74,6 @@ class CachingDatabase(private val wrappedDatabase: Database) : Database {
     override fun getSchedule(currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
         val email = wrappedDatabase.getCurrentEmail()
         currentShownMonday = currentWeekMonday
-        println("current week monday: $currentWeekMonday")
 
         if (!cachedSchedules.containsKey(email)) {  // If no cached schedule for that account, we fetch the schedule from the db
             return wrappedDatabase.getSchedule(currentWeekMonday).thenApply { schedule ->

--- a/app/src/main/java/com/github/sdpcoachme/database/CachingDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/CachingDatabase.kt
@@ -73,6 +73,7 @@ class CachingDatabase(private val wrappedDatabase: Database) : Database {
     override fun getSchedule(currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
         val email = wrappedDatabase.getCurrentEmail()
         currentShownMonday = currentWeekMonday
+        println("current week monday: $currentWeekMonday")
 
         if (!cachedSchedules.containsKey(email)) {  // If no cached schedule for that account, we fetch the schedule from the db
             return wrappedDatabase.getSchedule(currentWeekMonday).thenApply { schedule ->

--- a/app/src/main/java/com/github/sdpcoachme/database/CachingDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/CachingDatabase.kt
@@ -54,12 +54,12 @@ class CachingDatabase(private val wrappedDatabase: Database) : Database {
     }
 
     // Note: to efficiently use caching, we do not use the wrappedDatabase's addEventsToUser method
-    override fun addEvents(events: List<Event>, currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
+    override fun addEvent(event: Event, currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
         val email = wrappedDatabase.getCurrentEmail()
 
-        return wrappedDatabase.addEvents(events, currentWeekMonday).thenApply {
+        return wrappedDatabase.addEvent(event, currentWeekMonday).thenApply {
             // Update the cached schedule
-            cachedSchedules[email] = cachedSchedules[email]?.plus(events) ?: events.filter {
+            cachedSchedules[email] = cachedSchedules[email]?.plus(event) ?: listOf(event).filter {
                 val start = LocalDateTime.parse(it.start).toLocalDate()
                 val end = LocalDateTime.parse(it.end).toLocalDate()
                 start >= currentWeekMonday.minusWeeks(CACHED_SCHEDULE_WEEKS_BEHIND)

--- a/app/src/main/java/com/github/sdpcoachme/database/Database.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/Database.kt
@@ -65,10 +65,10 @@ interface Database {
     fun userExists(email: String): CompletableFuture<Boolean>
 
     /**
-     * Add events to the database
-     * @param events The events to add
+     * Add event to the database
+     * @param event The event to add
      * @param currentWeekMonday The monday of the current week
-     * @return A future with currently stored schedule that will complete when the events have been added.
+     * @return A future with currently stored schedule that will complete when the event has been added.
      */
     fun addEvent(event: Event, currentWeekMonday: LocalDate): CompletableFuture<Schedule>
 

--- a/app/src/main/java/com/github/sdpcoachme/database/Database.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/Database.kt
@@ -70,7 +70,7 @@ interface Database {
      * @param currentWeekMonday The monday of the current week
      * @return A future with currently stored schedule that will complete when the events have been added.
      */
-    fun addEvents(events: List<Event>, currentWeekMonday: LocalDate): CompletableFuture<Schedule>
+    fun addEvent(event: Event, currentWeekMonday: LocalDate): CompletableFuture<Schedule>
 
 
     /**

--- a/app/src/main/java/com/github/sdpcoachme/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/FireDatabase.kt
@@ -63,7 +63,8 @@ class FireDatabase(databaseReference: DatabaseReference) : Database {
     override fun getSchedule(currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
         val id = currEmail.replace('.', ',')
         return getChild(schedule, id).thenApply { it.getValue(Schedule::class.java)!! }
-            .exceptionally { Schedule() }
+            .exceptionally {
+                Schedule() }
     }
 
     override fun getCurrentEmail(): String {

--- a/app/src/main/java/com/github/sdpcoachme/database/FireDatabase.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/FireDatabase.kt
@@ -52,10 +52,10 @@ class FireDatabase(databaseReference: DatabaseReference) : Database {
         return childExists(accounts, userID)
     }
 
-    override fun addEvents(events: List<Event>, currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
+    override fun addEvent(event: Event, currentWeekMonday: LocalDate): CompletableFuture<Schedule> {
         val id = currEmail.replace('.', ',')
         return getSchedule(currentWeekMonday).thenCompose {
-            val updatedSchedule = it.copy(events = it.events + events)  // Add new events to the schedule
+            val updatedSchedule = it.copy(events = it.events + event)  // Add new events to the schedule
             setChild(schedule, id, updatedSchedule).thenApply { updatedSchedule }// Update DB
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -66,6 +66,7 @@ import com.maxkeppeler.sheets.clock.models.ClockSelection
 import com.maxkeppeler.sheets.color.ColorDialog
 import com.maxkeppeler.sheets.color.models.ColorConfig
 import com.maxkeppeler.sheets.color.models.ColorSelection
+import com.maxkeppeler.sheets.color.models.ColorSelectionMode
 import com.maxkeppeler.sheets.color.models.MultipleColors
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -89,6 +90,7 @@ class CreateEventActivity : ComponentActivity() {
                 val END_DATE_DIALOG_TITLE = text("endDateDialogTitle")
                 val START_TIME_DIALOG_TITLE = text("startTimeDialogTitle")
                 val END_TIME_DIALOG_TITLE = text("endTimeDialogTitle")
+                val COLOR_DIALOG_TITLE = text("colorDialogTitle")
             }
         }
 
@@ -102,12 +104,17 @@ class CreateEventActivity : ComponentActivity() {
                     return "${tag}Button"
                 }
 
+                private fun box(tag: String): String {
+                    return "${tag}Box"
+                }
+
                 val START_DATE = clickableText("startDate")
                 val START_TIME = clickableText("startTime")
                 val END_DATE = clickableText("endDate")
                 val END_TIME = clickableText("endTime")
                 val SAVE = button("save")
                 val CANCEL = button("cancel")
+                val COLOR_BOX = box("color")
             }
         }
 
@@ -136,7 +143,6 @@ class CreateEventActivity : ComponentActivity() {
 
         companion object {
             const val SCAFFOLD = "scaffold"
-            const val COLOR_BOX = "colorBox"
         }
     }
 
@@ -538,12 +544,26 @@ fun ColorRow(
 
         ColorDialog(
             state = colorSheet,
+            header = Header.Custom {
+                Text(
+                    text = "Select color",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CreateEventActivity.TestTags.Texts.COLOR_DIALOG_TITLE)
+                )
+            },
             selection = ColorSelection(
                 onSelectColor = {
                     onColorChange(colorMap[it] ?: EventColors.DEFAULT.color)
                 }
             ),
-            config = ColorConfig(templateColors = MultipleColors.ColorsInt(colorMap.keys.toList().dropLast(1))) //all except default
+            config = ColorConfig(
+                displayMode = ColorSelectionMode.TEMPLATE,
+                templateColors = MultipleColors.ColorsInt(colorMap.keys.toList().dropLast(1)), //all except default
+                allowCustomColorAlphaValues = false,
+            )
         )
         Box (
             modifier = Modifier
@@ -553,7 +573,7 @@ fun ColorRow(
                 .size(5.dp)
                 .clickable { colorSheet.show() }
                 .background(selectedColor)
-                .testTag(CreateEventActivity.TestTags.COLOR_BOX)
+                .testTag(CreateEventActivity.TestTags.Clickables.COLOR_BOX)
         )
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -3,12 +3,15 @@ package com.github.sdpcoachme.schedule
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.database.Database
@@ -31,6 +35,12 @@ import com.maxkeppeler.sheets.calendar.CalendarDialog
 import com.maxkeppeler.sheets.calendar.models.CalendarConfig
 import com.maxkeppeler.sheets.calendar.models.CalendarSelection
 import com.maxkeppeler.sheets.calendar.models.CalendarStyle
+import com.maxkeppeler.sheets.clock.ClockDialog
+import com.maxkeppeler.sheets.clock.models.ClockConfig
+import com.maxkeppeler.sheets.clock.models.ClockSelection
+import com.maxkeppeler.sheets.color.ColorDialog
+import com.maxkeppeler.sheets.color.models.ColorSelection
+import com.maxkeppeler.sheets.color.models.SingleColor
 import java.time.LocalDateTime
 
 class CreateEventActivity : ComponentActivity() {
@@ -41,8 +51,6 @@ class CreateEventActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         database = (application as CoachMeApplication).database
         email = database.getCurrentEmail()
-
-        println("Email: $email")
 
         if (email.isEmpty()) {
             val errorMsg = "New event did not receive an email address.\n Please return to the login page and try again."
@@ -62,110 +70,240 @@ class CreateEventActivity : ComponentActivity() {
 
 @Composable
 fun NewEvent() {
-    val startSheet = rememberSheetState()
-    val endSheet = rememberSheetState()
+    val startDateSheet = rememberSheetState()
+    val startTimeSheet = rememberSheetState()
+    val endDateSheet = rememberSheetState()
+    val endTimeSheet = rememberSheetState()
+    val colorSheet = rememberSheetState()
 
     var title by remember { mutableStateOf("") }
     var start by remember { mutableStateOf(LocalDateTime.now()) }
     var end by remember { mutableStateOf(LocalDateTime.now()) }
-    var color by remember { mutableStateOf(Color.Blue) }
+    var color by remember { mutableStateOf(SingleColor(Color.Blue.value.toInt())) }
     var description by remember { mutableStateOf("") }
 
     Column (
         modifier = Modifier
-            .padding(start = 20.dp)
+            .padding(start = 20.dp),
+        //horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Bottom
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.CenterHorizontally)
                 .height(56.dp)
         ) {
-            Text(
-                text = "Event Title: ",
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-            )
             OutlinedTextField(
                 value = title,
                 onValueChange = { title = it },
+                label = { Text("Event Title") },
                 modifier = Modifier
-                    .padding(start = 20.dp)
+                    //.padding(start = 20.dp)
                     .height(56.dp)
-                    .align(Alignment.CenterVertically)
             )
         }
 
 
         // Start date
-        CalendarDialog(
-            state = startSheet,
-            config = CalendarConfig(
-                monthSelection = true,
-                yearSelection = true,
-                style = CalendarStyle.MONTH,
-
-            ),
-            selection = CalendarSelection.Date {
-                start = it.atStartOfDay()
-            }
-        )
-
         Row (
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.CenterHorizontally)
-                .height(56.dp)
+                .height(56.dp),
+            verticalAlignment = Alignment.Bottom
         ){
             Text(
                 text = "Start Date: ",
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
+                    .weight(1f)
+
+            )
+            CalendarDialog(
+                state = startDateSheet,
+                config = CalendarConfig(
+                    monthSelection = true,
+                    yearSelection = true,
+                    style = CalendarStyle.MONTH,
+
+                    ),
+                selection = CalendarSelection.Date {
+                    start = it.atStartOfDay()
+                }
             )
             ClickableText(
                 text = AnnotatedString(start.toLocalDate().toString()),
-                onClick = { startSheet.show() },
+                onClick = { startDateSheet.show() },
+                style = MaterialTheme.typography.body1,
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
+                    .weight(1f)
             )
-
         }
 
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Text(
+                text = "Time: ",
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 20.dp)
+            )
+            ClockDialog(
+                state = startTimeSheet,
+                config = ClockConfig(
+                    is24HourFormat = true
+                ),
+                selection = ClockSelection.HoursMinutes { hours, minutes ->
+                    start = start.withHour(hours).withMinute(minutes)
+                }
+            )
+            ClickableText(
+                text = AnnotatedString(start.toLocalTime().format(EventOps.getEventTimeFormatter())),
+                onClick = { startTimeSheet.show() },
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .weight(1f)
+            )
+        }
 
         // End date
-        CalendarDialog(
-            state = endSheet,
-            config = CalendarConfig(
-                monthSelection = true,
-                yearSelection = true,
-                style = CalendarStyle.MONTH,
-            ),
-            selection = CalendarSelection.Date {
-                end = it.atStartOfDay().plusHours(1)
-            }
-        )
+        Row (
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            verticalAlignment = Alignment.Bottom
+        ){
+            Text(
+                text = "End Date: ",
+
+                modifier = Modifier
+                    .weight(1f)
+            )
+            CalendarDialog(
+                state = endDateSheet,
+                config = CalendarConfig(
+                    monthSelection = true,
+                    yearSelection = true,
+                    style = CalendarStyle.MONTH,
+                ),
+                selection = CalendarSelection.Date {
+                    end = it.atStartOfDay().plusHours(1)
+                }
+            )
+            ClickableText(
+                text = AnnotatedString(end.toLocalDate().toString()),
+                onClick = { endDateSheet.show() },
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .weight(1f)
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Text(
+                text = "Time: ",
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 20.dp)
+            )
+            ClockDialog(
+                state = endTimeSheet,
+                config = ClockConfig(
+                    is24HourFormat = true
+                ),
+                selection = ClockSelection.HoursMinutes { hours, minutes ->
+                    end = end.withHour(hours).withMinute(minutes)
+                }
+            )
+            ClickableText(
+                text = AnnotatedString(end.toLocalTime().format(EventOps.getEventTimeFormatter())),
+                onClick = { endTimeSheet.show() },
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .weight(1f)
+            )
+        }
 
         Row (
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.CenterHorizontally)
-                .height(56.dp)
-        ){
+                .height(56.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
             Text(
-                text = "End Date: ",
+                text = "Color: ",
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
+                    .weight(1f)
             )
-            ClickableText(
-                text = AnnotatedString(end.toLocalDate().toString()),
-                onClick = { endSheet.show() },
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
+            ColorDialog(
+                state = colorSheet,
+                selection = ColorSelection(
+                    selectedColor = color,
+                    onSelectColor = { color = SingleColor(it) }
+                )
             )
+        }
 
+        Row (
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(),
+            verticalAlignment = Alignment.Bottom
+        ){
+            OutlinedTextField(
+                value = description,
+                onValueChange = { description = it },
+                label = { Text("Description") },
+                modifier = Modifier
+                    .fillMaxHeight()
+            )
         }
     }
 }
+
+// TODO: Use that to modularize the date rows
+/*@Composable
+fun DateRow(startOrEnd: String, sheet: SheetState, date: LocalDateTime, setDate: (LocalDateTime) -> Unit) {
+    Row (
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp),
+        verticalAlignment = Alignment.Bottom
+    ){
+        Text(
+            text = "$startOrEnd Date: ",
+            modifier = Modifier
+                .weight(1f)
+
+        )
+        CalendarDialog(
+            state = sheet,
+            config = CalendarConfig(
+                monthSelection = true,
+                yearSelection = true,
+                style = CalendarStyle.MONTH,
+
+                ),
+            selection = CalendarSelection.Date { date ->
+                setDate(date.atStartOfDay())
+            }
+        )
+        ClickableText(
+            text = AnnotatedString(date.toLocalDate().toString()),
+            onClick = { sheet.show() },
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier
+                .weight(1f)
+        )
+    }
+}*/
 
 /*
 @Composable
@@ -207,3 +345,11 @@ fun NewEventTitleRow(modifier: Modifier = Modifier) {
         )
     }
 }*/
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    CoachMeTheme {
+        NewEvent()
+    }
+}

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -66,14 +67,76 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class CreateEventActivity : ComponentActivity() {
+    class TestTags {
+        class Texts {
+            companion object {
+                fun text(tag: String): String {
+                    return "${tag}Text"
+                }
+
+                val ACTIVITY_TITLE = text("activityTitle")
+                val START_DATE_TEXT = text("startDate")
+                val START_TIME_TEXT = text("startTime")
+                val END_DATE_TEXT = text("endDate")
+                val END_TIME_TEXT = text("endTime")
+                val COLOR_TEXT = text("color")
+            }
+        }
+
+        class Clickables {
+            companion object {
+                private fun clickableText(tag: String): String {
+                    return "${tag}ClickableText"
+                }
+
+                private fun button(tag: String): String {
+                    return "${tag}Button"
+                }
+
+                val START_DATE = clickableText("startDate")
+                val START_TIME = clickableText("startTime")
+                val END_DATE = clickableText("endDate")
+                val END_TIME = clickableText("endTime")
+                val SAVE = button("save")
+                val CANCEL = button("cancel")
+            }
+        }
+
+        class TextFields {
+            companion object {
+                fun textField(tag: String): String {
+                    return "${tag}TextField"
+                }
+
+                val EVENT_NAME = textField("eventName")
+                val DESCRIPTION = textField("description")
+            }
+        }
+
+        class Icons {
+            companion object {
+                fun icon(tag: String): String {
+                    return "${tag}Icon"
+                }
+
+                val SAVE_ICON = icon("save")
+                val CANCEL_ICON = icon("cancel")
+            }
+        }
+
+
+        companion object {
+            const val SCAFFOLD = "scaffold"
+            const val COLOR_BOX = "colorBox"
+        }
+    }
 
     private lateinit var database: Database
     private lateinit var email: String
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         database = (application as CoachMeApplication).database
-        email = intent.getStringExtra("email") ?: ""
-
+        email = database.getCurrentEmail()
         if (email.isEmpty()) {
             val errorMsg = "New event did not receive an email address.\n Please return to the login page and try again."
             ErrorHandlerLauncher().launchExtrasErrorHandler(this, errorMsg)
@@ -103,12 +166,13 @@ fun NewEvent(database: Database) {
     val formatterUserTime = EventOps.getTimeFormatter()
 
     var eventName by remember { mutableStateOf("") }
-    var start by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(8).withMinute(0)) }
-    var end by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(10).withMinute(0)) }
+    var start by remember { mutableStateOf(EventOps.getDefaultEventStart()) }
+    var end by remember { mutableStateOf(EventOps.getDefaultEventEnd()) }
     var description by remember { mutableStateOf("") }
-    var selectedColor by remember { mutableStateOf(EventColors.RED.color) }
+    var selectedColor by remember { mutableStateOf(EventColors.DEFAULT.color) }
 
     Scaffold(
+        modifier = Modifier.testTag(CreateEventActivity.TestTags.SCAFFOLD),
         topBar = {
             fun goBackToScheduleActivity() {
                 val intent = Intent(context, ScheduleActivity::class.java)
@@ -117,11 +181,22 @@ fun NewEvent(database: Database) {
             val event = Event(eventName, selectedColor.value.toString(), start.format(formatterEventDate), end.format(formatterEventDate), description)
             TopAppBar(
                 title = {
-                    Text("New Event")
+                    Text(
+                        text = "New Event",
+                        modifier = Modifier.testTag(CreateEventActivity.TestTags.Texts.ACTIVITY_TITLE)
+                    )
                 },
                 navigationIcon = {
-                    IconButton(onClick = { goBackToScheduleActivity() }) {
-                        Icon(Icons.Filled.Cancel, "Cancel")
+                    IconButton(
+                        onClick = { goBackToScheduleActivity() },
+                        modifier = Modifier.testTag(CreateEventActivity.TestTags.Clickables.CANCEL),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Cancel,
+                            contentDescription = "Cancel",
+                            tint = MaterialTheme.colors.onPrimary,
+                            modifier = Modifier.testTag(CreateEventActivity.TestTags.Icons.CANCEL_ICON),
+                        )
                     }
                 },
                 actions = {
@@ -131,9 +206,14 @@ fun NewEvent(database: Database) {
                                 goBackToScheduleActivity()
                             }
                         },
+                        modifier = Modifier.testTag(CreateEventActivity.TestTags.Clickables.SAVE),
                     ) {
-                        Icon(Icons.Filled.Done, "Done",
-                            tint = MaterialTheme.colors.onPrimary)
+                        Icon(
+                            imageVector = Icons.Filled.Done,
+                            contentDescription = "Done",
+                            tint = MaterialTheme.colors.onPrimary,
+                            modifier = Modifier.testTag(CreateEventActivity.TestTags.Icons.SAVE_ICON),
+                        )
                     }
                 })
         }
@@ -155,6 +235,7 @@ fun NewEvent(database: Database) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 10.dp)
+                    .testTag(CreateEventActivity.TestTags.TextFields.EVENT_NAME)
             )
 
             // Start date
@@ -218,6 +299,7 @@ fun StartDateRow(
             text = "Start Date: ",
             modifier = Modifier
                 .weight(1f)
+                .testTag(CreateEventActivity.TestTags.Texts.START_DATE_TEXT)
         )
         CalendarDialog(
             state = startDateSheet,
@@ -235,6 +317,7 @@ fun StartDateRow(
             style = MaterialTheme.typography.body1,
             modifier = Modifier
                 .weight(.8f)
+                .testTag(CreateEventActivity.TestTags.Clickables.START_DATE)
         )
     }
 }
@@ -257,6 +340,7 @@ fun StartTimeRow(
             modifier = Modifier
                 .weight(1f)
                 .padding(start = 20.dp)
+                .testTag(CreateEventActivity.TestTags.Texts.START_TIME_TEXT)
         )
         ClockDialog(
             state = startTimeSheet,
@@ -273,6 +357,7 @@ fun StartTimeRow(
             style = MaterialTheme.typography.body1,
             modifier = Modifier
                 .weight(.8f)
+                .testTag(CreateEventActivity.TestTags.Clickables.START_TIME)
         )
     }
 }
@@ -294,6 +379,7 @@ fun EndDateRow(
             text = "End Date: ",
             modifier = Modifier
                 .weight(1f)
+                .testTag(CreateEventActivity.TestTags.Texts.END_DATE_TEXT)
         )
         CalendarDialog(
             state = endDateSheet,
@@ -312,6 +398,7 @@ fun EndDateRow(
             style = MaterialTheme.typography.body1,
             modifier = Modifier
                 .weight(.8f)
+                .testTag(CreateEventActivity.TestTags.Clickables.END_DATE)
         )
     }
 }
@@ -334,6 +421,7 @@ fun EndTimeRow(
             modifier = Modifier
                 .weight(1f)
                 .padding(start = 20.dp)
+                .testTag(CreateEventActivity.TestTags.Texts.END_TIME_TEXT)
         )
         ClockDialog(
             state = endTimeSheet,
@@ -350,6 +438,7 @@ fun EndTimeRow(
             style = MaterialTheme.typography.body1,
             modifier = Modifier
                 .weight(.8f)
+                .testTag(CreateEventActivity.TestTags.Clickables.END_TIME)
         )
     }
 }
@@ -370,6 +459,7 @@ fun ColorRow(
             text = "Color: ",
             modifier = Modifier
                 .weight(1f)
+                .testTag(CreateEventActivity.TestTags.Texts.COLOR_TEXT)
         )
 
         val colorMap = mapOf(
@@ -388,10 +478,10 @@ fun ColorRow(
             state = colorSheet,
             selection = ColorSelection(
                 onSelectColor = {
-                    onColorChange(colorMap[it] ?: EventColors.RED.color)
+                    onColorChange(colorMap[it] ?: EventColors.DEFAULT.color)
                 }
             ),
-            config = ColorConfig(templateColors = MultipleColors.ColorsInt(colorMap.keys.toList()))
+            config = ColorConfig(templateColors = MultipleColors.ColorsInt(colorMap.keys.toList().dropLast(1))) //all except default
         )
         Box (
             modifier = Modifier
@@ -401,6 +491,7 @@ fun ColorRow(
                 .size(5.dp)
                 .clickable { colorSheet.show() }
                 .background(selectedColor)
+                .testTag(CreateEventActivity.TestTags.COLOR_BOX)
         )
     }
 }
@@ -416,14 +507,20 @@ fun DescriptionRow(
             .padding(top = 10.dp),
         verticalAlignment = Alignment.Bottom
     ){
+        val focusManager = LocalFocusManager.current
         TextField(
             value = description,
             onValueChange = { onDescriptionChange(it) },
             label = { Text("Description") },
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(
+                onNext = { focusManager.clearFocus() }
+            ),
             modifier = Modifier
                 .fillMaxHeight()
                 .fillMaxWidth()
                 .padding(top = 10.dp)
+                .testTag(CreateEventActivity.TestTags.TextFields.DESCRIPTION)
         )
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
@@ -88,6 +87,8 @@ class CreateEventActivity : ComponentActivity() {
 
                 val START_DATE_DIALOG_TITLE = text("startDateDialogTitle")
                 val END_DATE_DIALOG_TITLE = text("endDateDialogTitle")
+                val START_TIME_DIALOG_TITLE = text("startTimeDialogTitle")
+                val END_TIME_DIALOG_TITLE = text("endTimeDialogTitle")
             }
         }
 
@@ -368,6 +369,16 @@ fun StartTimeRow(
         )
         ClockDialog(
             state = startTimeSheet,
+            header = Header.Custom {
+                Text(
+                    text = "Start Time",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CreateEventActivity.TestTags.Texts.START_TIME_DIALOG_TITLE)
+                )
+            },
             config = ClockConfig(
                 defaultTime = start.toLocalTime(),
                 is24HourFormat = true
@@ -466,6 +477,16 @@ fun EndTimeRow(
         )
         ClockDialog(
             state = endTimeSheet,
+            header = Header.Custom {
+                Text(
+                    text = "End Time",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CreateEventActivity.TestTags.Texts.END_TIME_DIALOG_TITLE)
+                )
+            },
             config = ClockConfig(
                 is24HourFormat = true
             ),

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -1,0 +1,209 @@
+package com.github.sdpcoachme.schedule
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.github.sdpcoachme.CoachMeApplication
+import com.github.sdpcoachme.database.Database
+import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
+import com.github.sdpcoachme.ui.Dashboard
+import com.github.sdpcoachme.ui.theme.CoachMeTheme
+import com.maxkeppeker.sheets.core.models.base.rememberSheetState
+import com.maxkeppeler.sheets.calendar.CalendarDialog
+import com.maxkeppeler.sheets.calendar.models.CalendarConfig
+import com.maxkeppeler.sheets.calendar.models.CalendarSelection
+import com.maxkeppeler.sheets.calendar.models.CalendarStyle
+import java.time.LocalDateTime
+
+class CreateEventActivity : ComponentActivity() {
+
+    private lateinit var database: Database
+    private lateinit var email: String
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        database = (application as CoachMeApplication).database
+        email = database.getCurrentEmail()
+
+        println("Email: $email")
+
+        if (email.isEmpty()) {
+            val errorMsg = "New event did not receive an email address.\n Please return to the login page and try again."
+            ErrorHandlerLauncher().launchExtrasErrorHandler(this, errorMsg)
+        } else {
+
+            setContent {
+                CoachMeTheme {
+                    Dashboard("New Event") {
+                        NewEvent()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NewEvent() {
+    val startSheet = rememberSheetState()
+    val endSheet = rememberSheetState()
+
+    var title by remember { mutableStateOf("") }
+    var start by remember { mutableStateOf(LocalDateTime.now()) }
+    var end by remember { mutableStateOf(LocalDateTime.now()) }
+    var color by remember { mutableStateOf(Color.Blue) }
+    var description by remember { mutableStateOf("") }
+
+    Column (
+        modifier = Modifier
+            .padding(start = 20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally)
+                .height(56.dp)
+        ) {
+            Text(
+                text = "Event Title: ",
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            )
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                modifier = Modifier
+                    .padding(start = 20.dp)
+                    .height(56.dp)
+                    .align(Alignment.CenterVertically)
+            )
+        }
+
+
+        // Start date
+        CalendarDialog(
+            state = startSheet,
+            config = CalendarConfig(
+                monthSelection = true,
+                yearSelection = true,
+                style = CalendarStyle.MONTH,
+
+            ),
+            selection = CalendarSelection.Date {
+                start = it.atStartOfDay()
+            }
+        )
+
+        Row (
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally)
+                .height(56.dp)
+        ){
+            Text(
+                text = "Start Date: ",
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            )
+            ClickableText(
+                text = AnnotatedString(start.toLocalDate().toString()),
+                onClick = { startSheet.show() },
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            )
+
+        }
+
+
+        // End date
+        CalendarDialog(
+            state = endSheet,
+            config = CalendarConfig(
+                monthSelection = true,
+                yearSelection = true,
+                style = CalendarStyle.MONTH,
+            ),
+            selection = CalendarSelection.Date {
+                end = it.atStartOfDay().plusHours(1)
+            }
+        )
+
+        Row (
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally)
+                .height(56.dp)
+        ){
+            Text(
+                text = "End Date: ",
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            )
+            ClickableText(
+                text = AnnotatedString(end.toLocalDate().toString()),
+                onClick = { endSheet.show() },
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            )
+
+        }
+    }
+}
+
+/*
+@Composable
+fun NewEventTitleRow(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .background(Purple500)
+    ) {
+        // Button icon for the back button
+        IconButton(
+            onClick = {
+                // go back to the map view
+                val intent = Intent(context, MapActivity::class.java)
+                context.startActivity(intent)
+            },
+            modifier = Modifier
+                .testTag(ScheduleActivity.TestTags.Buttons.BACK)
+                .padding(start = 5.dp)
+                .align(Alignment.CenterVertically)
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "Back",
+                modifier = Modifier.align(Alignment.CenterVertically),
+                tint = Color.White
+            )
+        }
+        Text(
+            text = "Schedule",
+            style = MaterialTheme.typography.h5,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 20.sp,
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
+                .padding(start = 10.dp)
+        )
+    }
+}*/

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -330,8 +330,8 @@ fun StartDateRow(
                 )
             },
             config = CalendarConfig(
-                monthSelection = true,
-                yearSelection = true,
+                monthSelection = false,
+                yearSelection = false,
                 style = CalendarStyle.MONTH),
             selection = CalendarSelection.Date {
                 onDateChange(it.atStartOfDay())
@@ -437,8 +437,8 @@ fun EndDateRow(
             },
             state = endDateSheet,
             config = CalendarConfig(
-                monthSelection = true,
-                yearSelection = true,
+                monthSelection = false,
+                yearSelection = false,
                 style = CalendarStyle.MONTH,
             ),
             selection = CalendarSelection.Date {

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.data.schedule.Event
+import com.github.sdpcoachme.data.schedule.EventColors
 import com.github.sdpcoachme.database.Database
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
@@ -58,7 +59,6 @@ import com.maxkeppeler.sheets.color.ColorDialog
 import com.maxkeppeler.sheets.color.models.ColorConfig
 import com.maxkeppeler.sheets.color.models.ColorSelection
 import com.maxkeppeler.sheets.color.models.MultipleColors
-import com.maxkeppeler.sheets.color.models.SingleColor
 import java.time.LocalDateTime
 
 class CreateEventActivity : ComponentActivity() {
@@ -98,10 +98,8 @@ fun NewEvent(database: Database) {
     var eventName by remember { mutableStateOf("Test Event") }
     var start by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(8).withMinute(0)) }
     var end by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(10).withMinute(0)) }
-    var color by remember { mutableStateOf(0) }
     var description by remember { mutableStateOf("") }
-    var singleColor by remember { mutableStateOf(SingleColor()) }
-    var selectedColor by remember { mutableStateOf(Color.Red) }
+    var selectedColor by remember { mutableStateOf(EventColors.RED.color) }
 
     Scaffold(
         topBar = {
@@ -109,7 +107,6 @@ fun NewEvent(database: Database) {
                 val intent = Intent(context, ScheduleActivity::class.java)
                 context.startActivity(intent)
             }
-            println("signle color hex stirng: " + singleColor.colorHex)
             val event = Event(eventName, selectedColor.value.toString(), start.format(formatter), end.format(formatter), description)
             TopAppBar(
                 title = {
@@ -125,7 +122,6 @@ fun NewEvent(database: Database) {
                         onClick = {
                             EventOps.addEvent(event, database).thenAccept {
                                 goBackToScheduleActivity()
-                                println("add event returned")
                             }
                         },
                     ) {
@@ -138,7 +134,6 @@ fun NewEvent(database: Database) {
         Column (
             modifier = Modifier
                 .padding(start = 10.dp, end = 10.dp),
-            //verticalArrangement = Arrangement.Bottom
         ) {
             Row(
                 modifier = Modifier
@@ -284,7 +279,6 @@ fun NewEvent(database: Database) {
 
             Row (
                 modifier = Modifier
-                    //.fillMaxWidth()
                     .height(56.dp),
                 verticalAlignment = Alignment.Bottom
             ) {
@@ -294,34 +288,26 @@ fun NewEvent(database: Database) {
                         .weight(1f)
                 )
 
-                val predefinedColors = MultipleColors.ColorsInt(
-                    Color.Red.toArgb(),
-                    Color.Red.copy(alpha = 0.5f).toArgb(),
-                    Color.Green.toArgb(),
-                    Color.Blue.toArgb(),
+                val colorMap = mapOf(
+                    EventColors.RED.color.toArgb() to EventColors.RED.color,
+                    EventColors.SALMON.color.toArgb() to EventColors.SALMON.color,
+                    EventColors.ORANGE.color.toArgb() to EventColors.ORANGE.color,
+                    EventColors.LIME.color.toArgb() to EventColors.LIME.color,
+                    EventColors.MINT.color.toArgb() to EventColors.MINT.color,
+                    EventColors.DARK_GREEN.color.toArgb() to EventColors.DARK_GREEN.color,
+                    EventColors.BLUE.color.toArgb() to EventColors.BLUE.color,
+                    EventColors.LIGHT_BLUE.color.toArgb() to EventColors.LIGHT_BLUE.color,
+                    EventColors.PURPLE.color.toArgb() to EventColors.PURPLE.color,
                 )
+
                 ColorDialog(
                     state = colorSheet,
                     selection = ColorSelection(
-                        selectedColor = SingleColor(colorInt = color),
                         onSelectColor = {
-                            selectedColor = when (it) {
-                                Color.Red.toArgb() -> Color.Red
-                                Color.Green.toArgb() -> Color.Green
-                                Color.Blue.toArgb() -> Color.Blue
-                                else -> Color.Red
-                            }
-
-//                            println("color selected: $it")
-//                            color = it
-//                            singleColor = SingleColor(it)
-//
-//                            if (it == Color.Red.toArgb()) {
-//                                println("color is red")
-//                            }
+                            selectedColor = colorMap[it] ?: EventColors.RED.color
                         }
                     ),
-                    config = ColorConfig(templateColors = predefinedColors)
+                    config = ColorConfig(templateColors = MultipleColors.ColorsInt(colorMap.keys.toList()))
                 )
                 Box (
                     modifier = Modifier
@@ -330,7 +316,7 @@ fun NewEvent(database: Database) {
                         .aspectRatio(1f, true)
                         .size(5.dp)
                         .clickable { colorSheet.show() }
-                        //.background(Color(color.colorInt!!))
+                        .background(selectedColor)
                 )
             }
 

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -3,13 +3,18 @@ package com.github.sdpcoachme.schedule
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
@@ -22,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -79,12 +85,12 @@ fun NewEvent() {
     var title by remember { mutableStateOf("") }
     var start by remember { mutableStateOf(LocalDateTime.now()) }
     var end by remember { mutableStateOf(LocalDateTime.now()) }
-    var color by remember { mutableStateOf(SingleColor(Color.Blue.value.toInt())) }
+    var color by remember { mutableStateOf(SingleColor(Color.Blue.toArgb(), null, null)) }
     var description by remember { mutableStateOf("") }
 
     Column (
         modifier = Modifier
-            .padding(start = 20.dp),
+            .padding(start = 20.dp, end = 20.dp),
         //horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Bottom
     ) {
@@ -100,6 +106,7 @@ fun NewEvent() {
                 modifier = Modifier
                     //.padding(start = 20.dp)
                     .height(56.dp)
+                    .fillMaxWidth()
             )
         }
 
@@ -134,7 +141,7 @@ fun NewEvent() {
                 onClick = { startDateSheet.show() },
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier
-                    .weight(1f)
+                    .weight(.8f)
             )
         }
 
@@ -164,7 +171,7 @@ fun NewEvent() {
                 onClick = { startTimeSheet.show() },
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier
-                    .weight(1f)
+                    .weight(.8f)
             )
         }
 
@@ -197,7 +204,7 @@ fun NewEvent() {
                 onClick = { endDateSheet.show() },
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier
-                    .weight(1f)
+                    .weight(.8f)
             )
         }
 
@@ -227,7 +234,7 @@ fun NewEvent() {
                 onClick = { endTimeSheet.show() },
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier
-                    .weight(1f)
+                    .weight(.8f)
             )
         }
 
@@ -249,6 +256,15 @@ fun NewEvent() {
                     onSelectColor = { color = SingleColor(it) }
                 )
             )
+            Box (
+                modifier = Modifier
+                    .weight(.8f)
+                    .fillMaxHeight(.5f)
+                    .aspectRatio(1f, true)
+                    .size(10.dp)
+                    .clickable { colorSheet.show() }
+                    .background(Color(color.colorInt!!))
+            )
         }
 
         Row (
@@ -263,6 +279,7 @@ fun NewEvent() {
                 label = { Text("Description") },
                 modifier = Modifier
                     .fillMaxHeight()
+                    .fillMaxWidth()
             )
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,15 +17,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.ClickableText
-import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
-import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
@@ -39,17 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.database.Database
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
-import com.github.sdpcoachme.location.MapActivity
-import com.github.sdpcoachme.ui.Dashboard
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.github.sdpcoachme.ui.theme.Purple500
 import com.maxkeppeker.sheets.core.models.base.rememberSheetState
@@ -72,7 +66,7 @@ class CreateEventActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         database = (application as CoachMeApplication).database
-        email = database.getCurrentEmail()
+        email = intent.getStringExtra("email") ?: ""
 
         if (email.isEmpty()) {
             val errorMsg = "New event did not receive an email address.\n Please return to the login page and try again."
@@ -99,98 +93,58 @@ fun NewEvent(database: Database) {
     val formatter = EventOps.getEventTimeFormatter()
     val context = LocalContext.current
 
-    var title by remember { mutableStateOf("") }
-    var start by remember { mutableStateOf(LocalDateTime.now()) }
-    var end by remember { mutableStateOf(LocalDateTime.now()) }
+    var eventName by remember { mutableStateOf("Test Event") }
+    var start by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(8).withMinute(0)) }
+    var end by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(10).withMinute(0)) }
     var color by remember { mutableStateOf(SingleColor(Color.Blue.toArgb(), null, null)) }
     var description by remember { mutableStateOf("") }
 
-
-    //AddEventTitleRow(database, Event(title, color.colorInt.toString(), start.format(formatter), end.format(formatter), description))
-
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .background(Purple500)
-    ) {
-        fun goBackToScheduleActivity() {
-            val intent = Intent(context, ScheduleActivity::class.java)
-            context.startActivity(intent)
+    Scaffold(
+        topBar = {
+            fun goBackToScheduleActivity() {
+                val intent = Intent(context, ScheduleActivity::class.java)
+                println("Email in create activity database: ${database.getCurrentEmail()}")
+                intent.putExtra("email", database.getCurrentEmail())
+                context.startActivity(intent)
+            }
+            val event = Event(eventName, color.colorInt.toString(), start.format(formatter), end.format(formatter), description)
+            TopAppBar(
+                title = {
+                    Text("New Event")
+                },
+                navigationIcon = {
+                    IconButton(onClick = { goBackToScheduleActivity() }) {
+                        Icon(Icons.Filled.Cancel, "Cancel")
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            EventOps.addEvent(event, database)
+                            println("add event returned")
+                            goBackToScheduleActivity()
+                        },
+                    ) {
+                        Icon(Icons.Filled.Done, "Done",
+                            tint = MaterialTheme.colors.onPrimary)
+                    }
+                })
         }
-        val event = Event(title, color.colorInt.toString(), start.format(formatter), end.format(formatter), description)
-
-        // Button icon for the cancel button
-        IconButton(
-            onClick = {
-                goBackToScheduleActivity()
-            },
-            modifier = Modifier
-                .weight(1f)
-                .padding(start = 5.dp)
-                .align(Alignment.CenterVertically)
-        ) {
-            Icon(
-                imageVector = Icons.Default.Cancel,
-                contentDescription = "Cancel",
-                modifier = Modifier.align(Alignment.CenterVertically),
-                tint = Color.White
-            )
-        }
-
-        Text(
-            text = "New Event",
-            style = MaterialTheme.typography.h5,
-            color = Color.White,
-            fontWeight = FontWeight.Bold,
-            fontSize = 20.sp,
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .padding(start = 10.dp)
-        )
-
-        // Button icon for the save button
-        IconButton(
-            onClick = {
-                EventOps.addEvent(event, database)
-                goBackToScheduleActivity()
-            },
-            modifier = Modifier
-                .weight(1f)
-                .padding(end = 5.dp)
-                .align(Alignment.CenterVertically)
-        ) {
-            Icon(
-                imageVector = Icons.Default.Done,
-                contentDescription = "Save",
-                modifier = Modifier.align(Alignment.CenterVertically),
-                tint = Color.White
-            )
-        }
-    }
-
-    Row (
-        modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight()
-    ) {
+    ) {padding ->
         Column (
             modifier = Modifier
-                .padding(start = 20.dp, end = 20.dp),
-            verticalArrangement = Arrangement.Bottom
-
+                .padding(start = 10.dp, end = 10.dp),
+            //verticalArrangement = Arrangement.Bottom
         ) {
-
-
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(56.dp)
+                    .padding(top = 10.dp),
             ) {
-                OutlinedTextField(
-                    value = title,
-                    onValueChange = { title = it },
+                TextField(
+                    value = eventName,
+                    onValueChange = { eventName = it },
                     label = { Text("Event Title") },
                     singleLine = true,
                     modifier = Modifier
@@ -360,13 +314,14 @@ fun NewEvent(database: Database) {
                     .padding(top = 10.dp),
                 verticalAlignment = Alignment.Bottom
             ){
-                OutlinedTextField(
+                TextField(
                     value = description,
                     onValueChange = { description = it },
                     label = { Text("Description") },
                     modifier = Modifier
                         .fillMaxHeight()
                         .fillMaxWidth()
+                        .padding(top = 10.dp)
                 )
             }
         }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -2,6 +2,7 @@ package com.github.sdpcoachme.schedule
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
@@ -217,9 +218,15 @@ fun NewEvent(database: Database) {
                 actions = {
                     IconButton(
                         onClick = {
-                            EventOps.addEvent(event, database).thenAccept {
-                                goBackToScheduleActivity()
+                            if (start.isAfter(end)) {
+                                val toast = Toast.makeText(context, "Start date must be before end date", Toast.LENGTH_SHORT)
+                                toast.show()
+                            } else {
+                                EventOps.addEvent(event, database).thenAccept {
+                                    goBackToScheduleActivity()
+                                }
                             }
+
                         },
                         modifier = Modifier.testTag(CreateEventActivity.TestTags.Clickables.SAVE),
                     ) {

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -35,21 +35,26 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.data.schedule.EventColors
 import com.github.sdpcoachme.database.Database
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
+import com.maxkeppeker.sheets.core.models.base.Header
 import com.maxkeppeker.sheets.core.models.base.SheetState
 import com.maxkeppeker.sheets.core.models.base.rememberSheetState
 import com.maxkeppeler.sheets.calendar.CalendarDialog
@@ -80,6 +85,9 @@ class CreateEventActivity : ComponentActivity() {
                 val END_DATE_TEXT = text("endDate")
                 val END_TIME_TEXT = text("endTime")
                 val COLOR_TEXT = text("color")
+
+                val START_DATE_DIALOG_TITLE = text("startDateDialogTitle")
+                val END_DATE_DIALOG_TITLE = text("endDateDialogTitle")
             }
         }
 
@@ -282,6 +290,7 @@ fun NewEvent(database: Database) {
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun StartDateRow(
     startDateSheet: SheetState,
@@ -303,13 +312,28 @@ fun StartDateRow(
         )
         CalendarDialog(
             state = startDateSheet,
+            header = Header.Custom {
+                Text(
+                    text = "Start Date",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CreateEventActivity.TestTags.Texts.START_DATE_DIALOG_TITLE)
+                )
+            },
             config = CalendarConfig(
                 monthSelection = true,
                 yearSelection = true,
                 style = CalendarStyle.MONTH),
             selection = CalendarSelection.Date {
                 onDateChange(it.atStartOfDay())
-            }
+            },
+            properties = DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = true,
+                usePlatformDefaultWidth = true,
+            )
         )
         ClickableText(
             text = AnnotatedString(start.format(formatter)),
@@ -345,6 +369,7 @@ fun StartTimeRow(
         ClockDialog(
             state = startTimeSheet,
             config = ClockConfig(
+                defaultTime = start.toLocalTime(),
                 is24HourFormat = true
             ),
             selection = ClockSelection.HoursMinutes { hours, minutes ->
@@ -362,6 +387,7 @@ fun StartTimeRow(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EndDateRow(
     endDateSheet: SheetState,
@@ -382,6 +408,16 @@ fun EndDateRow(
                 .testTag(CreateEventActivity.TestTags.Texts.END_DATE_TEXT)
         )
         CalendarDialog(
+            header = Header.Custom {
+                Text(
+                    text = "End Date",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CreateEventActivity.TestTags.Texts.END_DATE_DIALOG_TITLE)
+                )
+            },
             state = endDateSheet,
             config = CalendarConfig(
                 monthSelection = true,
@@ -390,7 +426,12 @@ fun EndDateRow(
             ),
             selection = CalendarSelection.Date {
                 onDateChange(it.atStartOfDay().plusHours(1))
-            }
+            },
+            properties = DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = true,
+                usePlatformDefaultWidth = true,
+            )
         )
         ClickableText(
             text = AnnotatedString(end.format(formatter)),

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -100,7 +100,7 @@ fun NewEvent(database: Database) {
     val context = LocalContext.current
     val formatterEventDate = EventOps.getEventDateFormatter()
     val formatterUserDate = EventOps.getDayFormatter()
-    val formatterUserTime = EventOps.getEventTimeFormatter()
+    val formatterUserTime = EventOps.getTimeFormatter()
 
     var eventName by remember { mutableStateOf("") }
     var start by remember { mutableStateOf(LocalDateTime.now().plusDays(1).withHour(8).withMinute(0)) }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -23,6 +23,9 @@ class EventOps {
         private val DayFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")
         private val startMonday: LocalDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
 
+        private val defaultEventStart: LocalDateTime = LocalDateTime.now().plusDays(1).withHour(8).withMinute(0)
+        private val defaultEventEnd: LocalDateTime = defaultEventStart.plusHours(2)
+
         fun getMultiDayEventMap() = multiDayEventMap
 
         fun getEventDateFormatter() = EventDateFormatter
@@ -32,6 +35,10 @@ class EventOps {
         fun getDayFormatter() = DayFormatter
 
         fun getStartMonday() = startMonday
+
+        fun getDefaultEventStart() = defaultEventStart
+
+        fun getDefaultEventEnd() = defaultEventEnd
 
         /**
          * Function to wrap an event that spans multiple days into multiple events of type ShownEvent, one for each day.

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -40,6 +40,10 @@ class EventOps {
 
         fun getDefaultEventEnd() = defaultEventEnd
 
+        fun clearMultiDayEventMap() {
+            multiDayEventMap.clear()
+        }
+
         /**
          * Function to wrap an event that spans multiple days into multiple events of type ShownEvent, one for each day.
          *

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -20,14 +20,14 @@ class EventOps {
         private val multiDayEventMap = mutableMapOf<Event, List<ShownEvent>>()
         private val EventDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")
         private val TimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
-        private val DayFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")
-        private val startMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        private val DayFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")
+        private val startMonday: LocalDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
 
         fun getMultiDayEventMap() = multiDayEventMap
 
         fun getEventDateFormatter() = EventDateFormatter
 
-        fun getEventTimeFormatter() = TimeFormatter
+        fun getTimeFormatter() = TimeFormatter
 
         fun getDayFormatter() = DayFormatter
 
@@ -36,18 +36,13 @@ class EventOps {
         /**
          * Function to wrap an event that spans multiple days into multiple events of type ShownEvent, one for each day.
          *
-         * @param startDay The day the event starts on
-         * @param endDay The day the event ends on
          * @param event The event to wrap
-         * @param start The start time of the event
-         * @param end The end time of the event
          * @return A list of showable events that represent the event that spans multiple days
          *
          */
         private fun wrapEvent(
             event: Event
         ): List<ShownEvent> {
-            println("Event start: $event")
             val start = LocalDateTime.parse(event.start)
             val end = LocalDateTime.parse(event.end)
             val startDay = start.toLocalDate()
@@ -79,8 +74,6 @@ class EventOps {
             eventsToShow.add(startEvent)
             multiDayEventMap[event] = listOf(startEvent, endEvent)
 
-            println("Created new entry in multidayeventmap")
-
             if (daysToFill > 0) {
                 val middleEvents = (1..daysToFill).map { day ->
                     ShownEvent(
@@ -96,9 +89,8 @@ class EventOps {
                 eventsToShow.addAll(middleEvents)
                 multiDayEventMap[event] = multiDayEventMap[event]!! + middleEvents
             }
-            eventsToShow.add(endEvent)
 
-            println("Return eventsToShow")
+            eventsToShow.add(endEvent)
             return eventsToShow
         }
 
@@ -137,12 +129,10 @@ class EventOps {
         }
 
         fun addEvent(event: Event, database: Database): CompletableFuture<Schedule> {
-            println("App crashes between here")
             val shownEvents = wrapEvent(event)
             if (shownEvents.size > 1) {
                 multiDayEventMap[event] = shownEvents
             }
-            println("Add event finished")
             return database.addEvent(event, startMonday)
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -28,40 +28,6 @@ class EventOps {
         fun getStartMonday() = startMonday
 
         /**
-         * Function to convert a list of DB events to a list of events that can be shown on the schedule.
-         * If an event spans multiple days, it will be split into multiple events of type ShownEvent, one for each day.
-         *
-         * @param events The list of events to convert
-         * @return The list of events that can be shown on the schedule
-         */
-        fun eventsToWrappedEvents(events: List<Event>) : List<ShownEvent> {
-            val eventsToShow = mutableListOf<ShownEvent>()
-            events.forEach {
-                val start = LocalDateTime.parse(it.start)
-                val end = LocalDateTime.parse(it.end)
-                val startDay = start.toLocalDate()
-                val endDay = end.toLocalDate()
-
-                if (start.toLocalDate() != end.toLocalDate()) {
-                    val wrappedEvents = wrapEvent(startDay, endDay, it, start, end)
-                    eventsToShow.addAll(wrappedEvents)
-                } else {
-                    val shownEvent = ShownEvent(
-                        name = it.name,
-                        color = it.color,
-                        start = it.start,
-                        startText = start.toString(),
-                        end = it.end,
-                        endText = end.toString(),
-                        description = it.description,
-                    )
-                    eventsToShow.add(shownEvent)
-                }
-            }
-            return eventsToShow
-        }
-
-        /**
          * Function to wrap an event that spans multiple days into multiple events of type ShownEvent, one for each day.
          *
          * @param startDay The day the event starts on
@@ -120,5 +86,44 @@ class EventOps {
 
             return eventsToShow
         }
+
+        /**
+         * Function to convert a list of DB events to a list of events that can be shown on the schedule.
+         * If an event spans multiple days, it will be split into multiple events of type ShownEvent, one for each day.
+         *
+         * @param events The list of events to convert
+         * @return The list of events that can be shown on the schedule
+         */
+        fun eventsToWrappedEvents(events: List<Event>) : List<ShownEvent> {
+            val eventsToShow = mutableListOf<ShownEvent>()
+            events.forEach {
+                val start = LocalDateTime.parse(it.start)
+                val end = LocalDateTime.parse(it.end)
+                val startDay = start.toLocalDate()
+                val endDay = end.toLocalDate()
+
+                if (start.toLocalDate() != end.toLocalDate()) {
+                    val wrappedEvents = wrapEvent(startDay, endDay, it, start, end)
+                    eventsToShow.addAll(wrappedEvents)
+                } else {
+                    val shownEvent = ShownEvent(
+                        name = it.name,
+                        color = it.color,
+                        start = it.start,
+                        startText = start.toString(),
+                        end = it.end,
+                        endText = end.toString(),
+                        description = it.description,
+                    )
+                    eventsToShow.add(shownEvent)
+                }
+            }
+            return eventsToShow
+        }
+
+        fun launchAddEventActivity() {
+
+        }
+
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.data.schedule.ShownEvent
+import com.github.sdpcoachme.database.Database
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -41,30 +42,31 @@ class EventOps {
          *
          */
         private fun wrapEvent(
-            startDay: LocalDate,
-            endDay: LocalDate?,
-            event: Event,
-            start: LocalDateTime,
-            end: LocalDateTime
+            event: Event
         ): List<ShownEvent> {
+            val start = LocalDateTime.parse(event.start)
+            val end = LocalDateTime.parse(event.end)
+            val startDay = start.toLocalDate()
+            val endDay = end.toLocalDate()
+
             val eventsToShow = mutableListOf<ShownEvent>()
             val daysToFill = ChronoUnit.DAYS.between(startDay, endDay).toInt() - 1
             val startEvent = ShownEvent(
                 name = event.name,
                 color = event.color,
-                start = start.toString(),
-                startText = start.toString(),
+                start = event.start,
+                startText = event.start,
                 end = start.withHour(23).withMinute(59).withSecond(59).toString(),
-                endText = end.toString(),
+                endText = event.end,
                 description = event.description,
             )
             val endEvent = ShownEvent(
                 name = event.name,
                 color = event.color,
                 start = end.withHour(0).withMinute(0).withSecond(0).toString(),
-                startText = start.toString(),
-                end = end.toString(),
-                endText = end.toString(),
+                startText = event.start,
+                end = event.end,
+                endText = event.end,
                 description = event.description,
             )
             eventsToShow.add(startEvent)
@@ -75,9 +77,9 @@ class EventOps {
                         name = event.name,
                         color = event.color,
                         start = startDay.plusDays(day.toLong()).atTime(0, 0, 0).toString(),
-                        startText = start.toString(),
+                        startText = event.start,
                         end = startDay.plusDays(day.toLong()).atTime(23, 59, 59).toString(),
-                        endText = end.toString(),
+                        endText = event.end,
                         description = event.description,
                     )
                 }
@@ -99,22 +101,22 @@ class EventOps {
         fun eventsToWrappedEvents(events: List<Event>) : List<ShownEvent> {
             val eventsToShow = mutableListOf<ShownEvent>()
             events.forEach {
-                val start = LocalDateTime.parse(it.start)
-                val end = LocalDateTime.parse(it.end)
-                val startDay = start.toLocalDate()
-                val endDay = end.toLocalDate()
+                /*val start = LocalDateTime.parse(it.start)
+                val end = LocalDateTime.parse(it.end)*/
+                val startDay = LocalDateTime.parse(it.start).toLocalDate()
+                val endDay = LocalDateTime.parse(it.end).toLocalDate()
 
-                if (start.toLocalDate() != end.toLocalDate()) {
-                    val wrappedEvents = wrapEvent(startDay, endDay, it, start, end)
+                if (startDay != endDay) {
+                    val wrappedEvents = wrapEvent(it)
                     eventsToShow.addAll(wrappedEvents)
                 } else {
                     val shownEvent = ShownEvent(
                         name = it.name,
                         color = it.color,
                         start = it.start,
-                        startText = start.toString(),
+                        startText = it.start,
                         end = it.end,
-                        endText = end.toString(),
+                        endText = it.end,
                         description = it.description,
                     )
                     eventsToShow.add(shownEvent)
@@ -126,6 +128,14 @@ class EventOps {
         fun launchAddEventActivity(context: Context) {
             val intent = Intent(context, CreateEventActivity::class.java)
             context.startActivity(intent)
+        }
+
+        fun addEvent(event: Event, database: Database) {
+            database.addEvent(event, startMonday)
+            val shownEvents = wrapEvent(event)
+            if (shownEvents.size > 1) {
+                multiDayEventMap[event] = shownEvents
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -139,6 +139,15 @@ class EventOps {
             return eventsToShow
         }
 
+        /**
+         * Function to add an event to the database.
+         * If the event spans multiple days, it will be split into multiple events of type ShownEvent, one for each day.
+         * The multiDayEventMap will be updated accordingly.
+         *
+         * @param event The event to add
+         * @param database The database to add the event to
+         * @return A completable future that will be completed when the event has been added to the database
+         */
         fun addEvent(event: Event, database: Database): CompletableFuture<Schedule> {
             val shownEvents = wrapEvent(event)
             if (shownEvents.size > 1) {

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -132,7 +132,9 @@ class EventOps {
 
         fun addEvent(event: Event, database: Database) {
             database.addEvent(event, startMonday)
+            println("App crashes between here")
             val shownEvents = wrapEvent(event)
+            println("...and here")
             if (shownEvents.size > 1) {
                 multiDayEventMap[event] = shownEvents
             }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/EventOps.kt
@@ -1,5 +1,7 @@
 package com.github.sdpcoachme.schedule
 
+import android.content.Context
+import android.content.Intent
 import com.github.sdpcoachme.data.schedule.Event
 import com.github.sdpcoachme.data.schedule.ShownEvent
 import java.time.DayOfWeek
@@ -121,9 +123,9 @@ class EventOps {
             return eventsToShow
         }
 
-        fun launchAddEventActivity() {
-
+        fun launchAddEventActivity(context: Context) {
+            val intent = Intent(context, CreateEventActivity::class.java)
+            context.startActivity(intent)
         }
-
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -211,7 +211,9 @@ fun Schedule(
         }
 
         FloatingActionButton(
-            onClick = { EventOps.launchAddEventActivity() },
+            onClick = {
+                val intent = Intent(context, CreateEventActivity::class.java)
+                context.startActivity(intent) },
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp)

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -111,26 +111,22 @@ class ScheduleActivity : ComponentActivity() {
         database = (application as CoachMeApplication).database
         email = database.getCurrentEmail()
 
+        println("Email in schedule activity: $email")
+
         if (email.isEmpty()) {
             val errorMsg = "Schedule did not receive an email address.\n Please return to the login page and try again."
             ErrorHandlerLauncher().launchExtrasErrorHandler(this, errorMsg)
         } else {
             val startMonday = getStartMonday()
-            //TODO: For demo, let this function run once to add sample events to the database
-            //database.addEvents(sampleEvents, startMonday).thenRun {
-                val futureDBSchedule: CompletableFuture<Schedule> = database.getSchedule(startMonday).exceptionally {
-                    println("ScheduleActivity: Error getting schedule from database")
-                    null
-                }
+            val futureDBSchedule: CompletableFuture<Schedule> = database.getSchedule(startMonday)
 
-                setContent {
-                    CoachMeTheme {
-                        Surface(color = MaterialTheme.colors.background) {
-                            Schedule(futureDBSchedule, database)
-                        }
+            setContent {
+                CoachMeTheme {
+                    Surface(color = MaterialTheme.colors.background) {
+                        Schedule(futureDBSchedule, database)
                     }
                 }
-            //}
+            }
         }
     }
 }
@@ -213,6 +209,7 @@ fun Schedule(
         FloatingActionButton(
             onClick = {
                 val intent = Intent(context, CreateEventActivity::class.java)
+                intent.putExtra("email", database.getCurrentEmail())
                 context.startActivity(intent) },
             modifier = Modifier
                 .align(Alignment.BottomEnd)

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -61,17 +61,15 @@ import com.github.sdpcoachme.database.Database
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.location.MapActivity
 import com.github.sdpcoachme.schedule.EventOps.Companion.getDayFormatter
-import com.github.sdpcoachme.schedule.EventOps.Companion.getEventTimeFormatter
+import com.github.sdpcoachme.schedule.EventOps.Companion.getTimeFormatter
 import com.github.sdpcoachme.schedule.EventOps.Companion.getStartMonday
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.github.sdpcoachme.ui.theme.Purple500
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-import java.time.temporal.TemporalAdjusters
 import java.util.concurrent.CompletableFuture
 import kotlin.math.roundToInt
 
@@ -141,7 +139,7 @@ fun Schedule(
     modifier: Modifier = Modifier,
 ) {
     // the starting day is always the monday of the current week
-    var shownWeekMonday by remember { mutableStateOf<LocalDate>(getStartMonday()) }
+    var shownWeekMonday by remember { mutableStateOf(getStartMonday()) }
     var events by remember { mutableStateOf(emptyList<Event>()) }
     var eventsFuture by remember { mutableStateOf(futureDBSchedule.thenApply { Schedule(events = it.events) }) }
     val context = LocalContext.current
@@ -418,7 +416,7 @@ fun BasicSchedule(
 }
 
 private fun Modifier.eventData(event: ShownEvent) = this.then(EventDataModifier(event))
-private val EventTimeFormatter: DateTimeFormatter = getEventTimeFormatter()
+private val EventTimeFormatter: DateTimeFormatter = getTimeFormatter()
 private val DayFormatter = getDayFormatter()
 
 @Composable
@@ -455,68 +453,3 @@ fun BasicEvent(
         )
     }
 }
-
-
-// --------------------------------------------------
-// mainly for testing, debugging and demo purposes
-private val currentMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-private val lastMonday = currentMonday.minusDays(7)
-private val nextMonday = currentMonday.plusDays(7)
-private val sampleEvents = listOf(
-    Event(
-        name = "Google I/O Keynote",
-        color = Color(0xFFAFBBF2).value.toString(),
-        start = lastMonday.plusDays(1).atTime(13, 0, 0).toString(),
-        end = lastMonday.plusDays(1).atTime(15, 0, 0).toString(),
-        description = "Tune in to find out about how we're furthering our mission to organize the world’s information and make it universally accessible and useful.",
-    ),
-    Event(
-        name = "Business Trip",
-        color = Color(0xFFC9A776).value.toString(),
-        start = lastMonday.plusDays(4).atTime(9, 0, 0).toString(),
-        end = currentMonday.plusDays(1).atTime(18, 0, 0).toString(),
-        description = "I'm going to be out of the office for a business trip.",
-    ),
-    Event(
-        name = "Developer Keynote",
-        color = Color(0xFFAFBBF2).value.toString(),
-        start = currentMonday.plusDays(2).atTime(7, 0, 0).toString(),
-        end = currentMonday.plusDays(2).atTime(9, 0, 0).toString(),
-        description = "Learn about the latest updates to our developer products and platforms from Google Developers.",
-    ),
-    Event(
-        name = "What's new in Android",
-        color = Color(0xFF549C94).value.toString(),
-        start = currentMonday.plusDays(2).atTime(10, 0, 0).toString(),
-        end = currentMonday.plusDays(2).atTime(12, 0, 0).toString(),
-        description = "In this Keynote, Chet Haase, Dan Sandler, and Romain Guy discuss the latest Android features and enhancements for developers.",
-    ),
-    Event(
-        name = "What's new in Machine Learning",
-        color = Color(0xFFF4BFDB).value.toString(),
-        start = currentMonday.plusDays(2).atTime(22, 0, 0).toString(),
-        end = currentMonday.plusDays(3).atTime(4, 0, 0).toString(),
-        description = "Learn about the latest and greatest in ML from Google. We’ll cover what’s available to developers when it comes to creating, understanding, and deploying models for a variety of different applications.",
-    ),
-    Event(
-        name = "What's new in Material Design",
-        color = Color(0xFFC08A78).value.toString(),
-        start = currentMonday.plusDays(3).atTime(13, 0, 0).toString(),
-        end = currentMonday.plusDays(3).atTime(15, 0, 0).toString(),
-        description = "Learn about the latest design improvements to help you build personal dynamic experiences with Material Design.",
-    ),
-    Event(
-        name = "Jetpack Compose Basics",
-        color = Color(0xFFB98FC0).value.toString(),
-        start = nextMonday.plusDays(4).atTime(9, 0, 0).toString(),
-        end = nextMonday.plusDays(4).atTime(13, 0, 0).toString(),
-        description = "This Workshop will take you through the basics of building your first app with Jetpack Compose, Android's new modern UI toolkit that simplifies and accelerates UI development on Android.",
-    ),
-    Event(
-        name = "Holidays",
-        color = Color(0xFF71A5CE).value.toString(),
-        start = currentMonday.plusDays(4).atTime(14, 0, 0).toString(),
-        end = nextMonday.plusDays(1).atTime(18, 0, 0).toString(),
-        description = "A few days off to relax and enjoy the holidays.",
-    ),
-)

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -19,12 +19,14 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowLeft
 import androidx.compose.material.icons.filled.ArrowRight
@@ -84,6 +86,7 @@ class ScheduleActivity : ComponentActivity() {
                 const val LEFT_ARROW_BUTTON = "leftArrowButton"
                 const val RIGHT_ARROW_BUTTON = "rightArrowButton"
                 const val BACK = "backButton"
+                const val ADD_EVENT_BUTTON = "addEventButton"
             }
         }
         class TextFields {
@@ -176,34 +179,49 @@ fun Schedule(
         }
     }
 
-    Column(modifier = modifier
-        .testTag(ScheduleActivity.TestTags.SCHEDULE_COLUMN)
-    ) {
-        ScheduleTitleRow(
-            shownWeekMonday = shownWeekMonday,
-            onLeftArrowClick = { updateCurrentWeekMonday(-1) },
-            onRightArrowClick = { updateCurrentWeekMonday(1) },
-        )
+    Box(modifier = modifier) {
+        Column(modifier = modifier
+            .testTag(ScheduleActivity.TestTags.SCHEDULE_COLUMN)
+        ) {
+            ScheduleTitleRow(
+                shownWeekMonday = shownWeekMonday,
+                onLeftArrowClick = { updateCurrentWeekMonday(-1) },
+                onRightArrowClick = { updateCurrentWeekMonday(1) },
+            )
 
-        WeekHeader(
-            shownWeekMonday = shownWeekMonday,
-            dayWidth = dayWidth,
-        )
+            WeekHeader(
+                shownWeekMonday = shownWeekMonday,
+                dayWidth = dayWidth,
+            )
 
-        // filter events to only show events in the current week
-        val eventsToShow = EventOps.eventsToWrappedEvents(events)
-        BasicSchedule(
-            events = eventsToShow.filter {event ->
-                val eventDate = LocalDateTime.parse(event.start).toLocalDate()
-                eventDate >= shownWeekMonday && eventDate < shownWeekMonday.plusWeeks(1)
-            },
-            shownMonday = shownWeekMonday,
-            dayWidth = dayWidth,
+            // filter events to only show events in the current week
+            val eventsToShow = EventOps.eventsToWrappedEvents(events)
+            BasicSchedule(
+                events = eventsToShow.filter { event ->
+                    val eventDate = LocalDateTime.parse(event.start).toLocalDate()
+                    eventDate >= shownWeekMonday && eventDate < shownWeekMonday.plusWeeks(1)
+                },
+                shownMonday = shownWeekMonday,
+                dayWidth = dayWidth,
+                modifier = Modifier
+                    .weight(1f) // Fill remaining space in the column
+                    .verticalScroll(verticalScrollState)
+                    .testTag(ScheduleActivity.TestTags.BASIC_SCHEDULE)
+            )
+        }
+
+        FloatingActionButton(
+            onClick = { EventOps.launchAddEventActivity() },
             modifier = Modifier
-                .weight(1f) // Fill remaining space in the column
-                .verticalScroll(verticalScrollState)
-                .testTag(ScheduleActivity.TestTags.BASIC_SCHEDULE)
-        )
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+                .testTag(ScheduleActivity.TestTags.Buttons.ADD_EVENT_BUTTON),
+            backgroundColor = Purple500) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "Add Event"
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -111,8 +111,6 @@ class ScheduleActivity : ComponentActivity() {
         database = (application as CoachMeApplication).database
         email = database.getCurrentEmail()
 
-        println("Email in schedule activity: $email")
-
         if (email.isEmpty()) {
             val errorMsg = "Schedule did not receive an email address.\n Please return to the login page and try again."
             ErrorHandlerLauncher().launchExtrasErrorHandler(this, errorMsg)
@@ -190,8 +188,10 @@ fun Schedule(
                 dayWidth = dayWidth,
             )
 
+            println("Get shown events")
             // filter events to only show events in the current week
             val eventsToShow = EventOps.eventsToWrappedEvents(events)
+            println("Events to show: $eventsToShow")
             BasicSchedule(
                 events = eventsToShow.filter { event ->
                     val eventDate = LocalDateTime.parse(event.start).toLocalDate()

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -186,10 +186,8 @@ fun Schedule(
                 dayWidth = dayWidth,
             )
 
-            println("Get shown events")
             // filter events to only show events in the current week
             val eventsToShow = EventOps.eventsToWrappedEvents(events)
-            println("Events to show: $eventsToShow")
             BasicSchedule(
                 events = eventsToShow.filter { event ->
                     val eventDate = LocalDateTime.parse(event.start).toLocalDate()

--- a/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/ScheduleActivity.kt
@@ -207,7 +207,6 @@ fun Schedule(
         FloatingActionButton(
             onClick = {
                 val intent = Intent(context, CreateEventActivity::class.java)
-                intent.putExtra("email", database.getCurrentEmail())
                 context.startActivity(intent) },
             modifier = Modifier
                 .align(Alignment.BottomEnd)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="title_activity_login">Log in</string>
     <string name="title_activity_multiselect_list">Choose sports</string>
     <string name="title_activity_schedule">Schedule</string>
+    <string name="title_activity_create_event">Create event</string>
     <string name="title_activity_chats_overview">Chats overview</string>
     <string name="title_activity_chat">Chat</string>
     <string name="title_activity_map">Map</string>

--- a/app/src/test/java/com/github/sdpcoachme/ExampleUnitTest.kt
+++ b/app/src/test/java/com/github/sdpcoachme/ExampleUnitTest.kt
@@ -1,5 +1,7 @@
 package com.github.sdpcoachme
 
+import androidx.compose.ui.graphics.Color
+import com.maxkeppeler.sheets.color.models.SingleColor
 import org.junit.Test
 
 import org.junit.Assert.*
@@ -13,5 +15,17 @@ class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
         assertEquals(4, 2 + 2)
+    }
+
+    @Test
+    fun colorTest() {
+//        val color = SingleColor(0xFF0000FF.toInt())
+//        val colorString = color.colorInt.toString()
+        val colorString = "18446744073692774655"
+
+        val number = colorString.toULong()
+        val result = Color(number)
+
+        println("result: ${result.value}")
     }
 }

--- a/app/src/test/java/com/github/sdpcoachme/ExampleUnitTest.kt
+++ b/app/src/test/java/com/github/sdpcoachme/ExampleUnitTest.kt
@@ -1,10 +1,7 @@
 package com.github.sdpcoachme
 
-import androidx.compose.ui.graphics.Color
-import com.maxkeppeler.sheets.color.models.SingleColor
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -17,15 +14,4 @@ class ExampleUnitTest {
         assertEquals(4, 2 + 2)
     }
 
-    @Test
-    fun colorTest() {
-//        val color = SingleColor(0xFF0000FF.toInt())
-//        val colorString = color.colorInt.toString()
-        val colorString = "18446744073692774655"
-
-        val number = colorString.toULong()
-        val result = Color(number)
-
-        println("result: ${result.value}")
-    }
 }


### PR DESCRIPTION
# Add custom events
This PR will add the possibility for users to add their own events to the schedule. 
In the schedule, one can see an icon button on the bottom right. When clicking that button, a new activity will be launched. In that activity, users can choose the event title, start, end, color, and description. Once the event is confirmed, it will be added to the database and will be displayed in the schedule.

For picking the date, time, and color, an existing library was used. This allowed me to reuse existing pickers that work. The downside of using that library is that all those pickers come without modifier parameters. So, it is not possible to assign a testtag to elements that are internal to a picker. That made it a bit harder to test everything. Some cases, I was not able to test. 
Anyway, considering the big amount of code that this PR will add, the missing test cases won't decrease code coverage (or at least not much).