### PR TITLE
Filter by sport

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/location/provider/MockLocationProvider.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/location/provider/MockLocationProvider.kt
@@ -38,6 +38,10 @@ class MockLocationProvider: LocationProvider {
         withPermission = false
     }
 
+    fun setMockLocation(location: LatLng) {
+        mockLocation.value = location
+    }
+
     override fun init(context: ComponentActivity, userInfo: CompletableFuture<UserInfo>) {
         appContext = context
         user = userInfo

--- a/app/src/androidTest/java/com/github/sdpcoachme/location/provider/MockLocationProvider.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/location/provider/MockLocationProvider.kt
@@ -38,10 +38,6 @@ class MockLocationProvider: LocationProvider {
         withPermission = false
     }
 
-    fun setMockLocation(location: LatLng) {
-        mockLocation.value = location
-    }
-
     override fun init(context: ComponentActivity, userInfo: CompletableFuture<UserInfo>) {
         appContext = context
         user = userInfo

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -12,7 +12,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.R
-import com.github.sdpcoachme.data.Sports
 import com.github.sdpcoachme.data.UserAddressSamples.Companion.LAUSANNE
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.data.UserInfoSamples.Companion.COACHES
@@ -184,7 +183,7 @@ open class CoachesListActivityTest {
                 "0987654321",
                 LAUSANNE,
                 false,
-                Sports.values().toList(),
+                emptyList(),
                 emptyList()
             )
             composeTestRule.onNodeWithText(coach.address.name).assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -132,7 +132,6 @@ open class CoachesListActivityTest {
             composeTestRule.onNodeWithTag(BAR_TITLE).assertExists().assertIsDisplayed()
             composeTestRule.onNodeWithTag(BAR_TITLE).assert(hasText(title))
         }
-        println(database.getAllUsers().join())
     }
     @Test
     fun dashboardIsAccessibleAndDisplayableFromNearbyCoachesList() {

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -23,7 +23,10 @@ import com.github.sdpcoachme.data.UserAddressSamples.Companion.LAUSANNE
 import com.github.sdpcoachme.database.MockDatabase
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.Buttons.Companion.GO_TO_LOGIN_BUTTON
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.TextFields.Companion.ERROR_MESSAGE_FIELD
+import com.github.sdpcoachme.location.provider.MockLocationProvider
 import com.github.sdpcoachme.messaging.ChatActivity
+import com.github.sdpcoachme.profile.CoachesListActivity.TestTags.Buttons.Companion.FILTER
+import com.google.android.gms.maps.model.LatLng
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.After
 import org.junit.Before
@@ -46,6 +49,12 @@ open class CoachesListActivityTest {
 
     lateinit var scenario: ActivityScenario<CoachesListActivity>
 
+    private val mockLocationProvider = (InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as CoachMeApplication)
+        .locationProvider as MockLocationProvider
+
+    val LAUS = LatLng(LAUSANNE.latitude, LAUSANNE.longitude)
+
     // With this, tests will wait until activity has finished loading state
     @Before
     open fun setup() {
@@ -53,6 +62,8 @@ open class CoachesListActivityTest {
         // TODO: this is temporary, we should find a better way to guarantee the database is refreshed
         //  before each test
         database.restoreDefaultAccountsSetup()
+        mockLocationProvider.setMockLocation(LAUS)
+
         // Populate the database, and wait for it to finish
         populateDatabase().join()
         scenario = ActivityScenario.launch(defaultIntent)
@@ -159,6 +170,10 @@ open class CoachesListActivityTest {
         override fun setup() {
             // Launch the activity
             populateDatabase().join()
+            ((InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext as CoachMeApplication)
+                .locationProvider as MockLocationProvider).setMockLocation(LAUS)
+
             val contactIntent = Intent(ApplicationProvider.getApplicationContext(), CoachesListActivity::class.java)
             contactIntent.putExtra("isViewingContacts", true)
             scenario = ActivityScenario.launch(contactIntent)
@@ -212,6 +227,10 @@ open class CoachesListActivityTest {
             composeTestRule.onNodeWithTag(DRAWER_HEADER).assertExists().assertIsDisplayed()
         }
 
+        @Test
+        fun filteringButtonIsNotShownInContactsList() {
+            composeTestRule.onNodeWithTag(FILTER).assertDoesNotExist()
+        }
 
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -154,6 +154,19 @@ open class CoachesListActivityTest {
         }
     }
 
+    @Test
+    fun filteringButtonIsShownInNearbyCoaches() {
+        composeTestRule.onNodeWithTag(FILTER).assertExists().assertIsDisplayed()
+    }
+
+    @Test
+    fun filteringButtonLaunchesSelectSportsActivity() {
+        composeTestRule.onNodeWithTag(FILTER).assertExists().assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FILTER).performClick()
+        Intents.intended(allOf(hasComponent(SelectSportsActivity::class.java.name),
+            hasExtra("title", "Filter coaches by sport")))
+    }
+
     // Subclass added to be able to run a different setup method (to simulate viewing contacts)
     class ContactsListTest: CoachesListActivityTest() {
         @Before

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.R
+import com.github.sdpcoachme.data.Sports
 import com.github.sdpcoachme.data.UserAddressSamples.Companion.LAUSANNE
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.data.UserInfoSamples.Companion.COACHES
@@ -77,12 +78,14 @@ open class CoachesListActivityTest {
             stateLoading = it.stateLoading
         }
         stateLoading.get(1000, MILLISECONDS)
+        Intents.init()
     }
 
     // Necessary since we don't do scenario.use { ... } in each test, which closes automatically
     @After
-    fun cleanup() {
+    open fun cleanup() {
         scenario.close()
+        Intents.release()
     }
 
     @Test
@@ -107,8 +110,6 @@ open class CoachesListActivityTest {
 
     @Test
     fun whenClickingOnACoachProfileActivityShowsCoachToClient() {
-            Intents.init()
-
             // Click on the first coach
             val coach = COACH_1
             composeTestRule.onNodeWithText(coach.address.name).assertIsDisplayed()
@@ -122,8 +123,6 @@ open class CoachesListActivityTest {
                 hasExtra("email", coach.email),
                 hasExtra("isViewingCoach", true)
             ))
-
-            Intents.release()
     }
 
     @Test
@@ -134,6 +133,7 @@ open class CoachesListActivityTest {
             composeTestRule.onNodeWithTag(BAR_TITLE).assertExists().assertIsDisplayed()
             composeTestRule.onNodeWithTag(BAR_TITLE).assert(hasText(title))
         }
+        println(database.getAllUsers().join())
     }
     @Test
     fun dashboardIsAccessibleAndDisplayableFromNearbyCoachesList() {
@@ -171,11 +171,11 @@ open class CoachesListActivityTest {
                 stateLoading = it.stateLoading
             }
             stateLoading.get(1000, MILLISECONDS)
+            Intents.init()
         }
 
         @Test
         fun whenViewingContactsAndClickingOnClientChatActivityIsLaunched() {
-            Intents.init()
             val toEmail = "to@email.com"
             val coach = UserInfo(
                 "Jane",
@@ -184,7 +184,7 @@ open class CoachesListActivityTest {
                 "0987654321",
                 LAUSANNE,
                 false,
-                emptyList(),
+                Sports.values().toList(),
                 emptyList()
             )
             composeTestRule.onNodeWithText(coach.address.name).assertIsDisplayed()
@@ -197,7 +197,6 @@ open class CoachesListActivityTest {
                 hasComponent(ChatActivity::class.java.name),
                 hasExtra("toUserEmail", coach.email),
             ))
-            Intents.release()
         }
 
         @Test

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -12,21 +12,19 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.R
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.HAMBURGER_MENU
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.BAR_TITLE
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.DRAWER_HEADER
+import com.github.sdpcoachme.data.UserAddressSamples.Companion.LAUSANNE
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.data.UserInfoSamples.Companion.COACHES
 import com.github.sdpcoachme.data.UserInfoSamples.Companion.COACH_1
 import com.github.sdpcoachme.data.UserInfoSamples.Companion.NON_COACHES
-import com.github.sdpcoachme.data.UserAddressSamples.Companion.LAUSANNE
 import com.github.sdpcoachme.database.MockDatabase
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.Buttons.Companion.GO_TO_LOGIN_BUTTON
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.TextFields.Companion.ERROR_MESSAGE_FIELD
-import com.github.sdpcoachme.location.provider.MockLocationProvider
 import com.github.sdpcoachme.messaging.ChatActivity
 import com.github.sdpcoachme.profile.CoachesListActivity.TestTags.Buttons.Companion.FILTER
-import com.google.android.gms.maps.model.LatLng
+import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.HAMBURGER_MENU
+import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.BAR_TITLE
+import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.DRAWER_HEADER
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.After
 import org.junit.Before
@@ -49,12 +47,6 @@ open class CoachesListActivityTest {
 
     lateinit var scenario: ActivityScenario<CoachesListActivity>
 
-    private val mockLocationProvider = (InstrumentationRegistry.getInstrumentation()
-            .targetContext.applicationContext as CoachMeApplication)
-        .locationProvider as MockLocationProvider
-
-    val LAUS = LatLng(LAUSANNE.latitude, LAUSANNE.longitude)
-
     // With this, tests will wait until activity has finished loading state
     @Before
     open fun setup() {
@@ -62,7 +54,6 @@ open class CoachesListActivityTest {
         // TODO: this is temporary, we should find a better way to guarantee the database is refreshed
         //  before each test
         database.restoreDefaultAccountsSetup()
-        mockLocationProvider.setMockLocation(LAUS)
 
         // Populate the database, and wait for it to finish
         populateDatabase().join()
@@ -170,9 +161,6 @@ open class CoachesListActivityTest {
         override fun setup() {
             // Launch the activity
             populateDatabase().join()
-            ((InstrumentationRegistry.getInstrumentation()
-                .targetContext.applicationContext as CoachMeApplication)
-                .locationProvider as MockLocationProvider).setMockLocation(LAUS)
 
             val contactIntent = Intent(ApplicationProvider.getApplicationContext(), CoachesListActivity::class.java)
             contactIntent.putExtra("isViewingContacts", true)

--- a/app/src/main/java/com/github/sdpcoachme/location/provider/FusedLocationProvider.kt
+++ b/app/src/main/java/com/github/sdpcoachme/location/provider/FusedLocationProvider.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.content.ContextCompat
 import com.github.sdpcoachme.data.UserInfo
+import com.github.sdpcoachme.location.MapActivity
 import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.location.*
 import com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY
@@ -57,7 +58,13 @@ class FusedLocationProvider : LocationProvider {
     override fun init(context: ComponentActivity, userInfo: CompletableFuture<UserInfo>) {
         appContext = context
         user = userInfo
-        lastUserLocation = mutableStateOf(null)
+        // Only the MapActivity initializes the location as it is guaranteed to be set in its
+        // context. For other activities, we launch init on the LocationProvider of the app while
+        // maintaining the lastUserLocation state.
+        // This allows single activity launch tests, ie without launching the MapActivity first.
+        if (context is MapActivity) {
+            lastUserLocation = mutableStateOf(null)
+        }
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(appContext)
 
         requestPermissionLauncher = appContext.registerForActivityResult(

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -136,7 +136,8 @@ class CoachesListActivity : ComponentActivity() {
             LazyColumn {
                 items(listOfCoaches) {user ->
                     // Filtering should not influence the coaches list in contacts view
-                    if (!Collections.disjoint(user.sports, sportsFilter.value)) {
+                    // We still show user with no favourite sports, especially for testing purposes
+                    if (user.sports.isEmpty() || !Collections.disjoint(user.sports, sportsFilter.value)) {
                         UserInfoListItem(user, isViewingContacts)
                     }
                 }

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -63,9 +63,12 @@ class CoachesListActivity : ComponentActivity() {
 
         val isViewingContacts = intent.getBooleanExtra("isViewingContacts", false)
         val database = (application as CoachMeApplication).database
-        val lastLocation = (application as CoachMeApplication).locationProvider.getLastLocation()
-        val userLatLng = lastLocation.value?: CAMPUS
         val email = database.getCurrentEmail()
+
+        val locationProvider = (application as CoachMeApplication).locationProvider
+        // Here we don't need the UserInfo
+        locationProvider.init(this, CompletableFuture.completedFuture(null))
+        val userLatLng = locationProvider.getLastLocation().value?: CAMPUS
 
         // initially all sports are selected
         sportsFilter = mutableStateOf(Sports.values().toList())

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -54,6 +54,7 @@ class CoachesListActivity : ComponentActivity() {
     // Allows to notice testing framework that the activity is ready
     var stateLoading = CompletableFuture<Void>()
 
+    // Observable state of the current sports used to filter the coaches list
     private lateinit var sportsFilter: MutableState<List<Sports>>
     private lateinit var selectSportsHandler: (Intent) -> CompletableFuture<List<Sports>>
 
@@ -116,6 +117,9 @@ class CoachesListActivity : ComponentActivity() {
         }
     }
 
+    /**
+     * Displays a list of nearby coaches or messaging contacts.
+     */
     @Composable()
     fun CoachesList(
         modifier: Modifier,
@@ -128,31 +132,36 @@ class CoachesListActivity : ComponentActivity() {
         Box(modifier = modifier.fillMaxSize()) {
             LazyColumn {
                 items(listOfCoaches) {user ->
+                    // Filtering should not influence the coaches list in contacts view
                     if (!Collections.disjoint(user.sports, sportsFilter.value)) {
                         UserInfoListItem(user, isViewingContacts)
                     }
                 }
             }
-            FloatingActionButton(
-                onClick = {
-//                    this@CoachesListActivity.sportsFilter.value =
-                    selectSportsHandler(
+            if (!isViewingContacts) {
+                // Button to add a sport filter for the shown coaches list.
+                FloatingActionButton(
+                    onClick = {
+                        // Updates the sportsFilter state with the result of the SelectSportsActivity
+                        // which relaunches the CoachesList composable on state change.
+                        selectSportsHandler(
                             SelectSportsActivity.getIntent(
                                 context = context,
                                 title = "Filter coaches by sport",
                                 initialValue = sportsFilter.value
                             )).thenApply {sportsFilter.value = it }
-                },
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp)
-                    .testTag(FILTER),
-                backgroundColor = Purple200
-            ) {
-                Icon(
-                    imageVector = Default.Tune,
-                    contentDescription = "Filter nearby coaches by sport"
-                )
+                    },
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp)
+                        .testTag(FILTER),
+                    backgroundColor = Purple200
+                ) {
+                    Icon(
+                        imageVector = Default.Tune,
+                        contentDescription = "Filter nearby coaches by sports"
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -11,36 +11,52 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons.Default
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.R
+import com.github.sdpcoachme.data.Sports
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.location.provider.FusedLocationProvider.Companion.CAMPUS
 import com.github.sdpcoachme.messaging.ChatActivity
+import com.github.sdpcoachme.profile.CoachesListActivity.TestTags.Buttons.Companion.FILTER
 import com.github.sdpcoachme.ui.Dashboard
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
+import com.github.sdpcoachme.ui.theme.Purple200
 import kotlinx.coroutines.future.await
+import java.util.*
 import java.util.concurrent.CompletableFuture
 
 class CoachesListActivity : ComponentActivity() {
+
+    class TestTags {
+        class Buttons {
+            companion object {
+                const val FILTER = "filterSearch"
+            }
+        }
+    }
+
     // Allows to notice testing framework that the activity is ready
     var stateLoading = CompletableFuture<Void>()
+
+    private lateinit var sportsFilter: MutableState<List<Sports>>
+    private lateinit var selectSportsHandler: (Intent) -> CompletableFuture<List<Sports>>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -49,6 +65,10 @@ class CoachesListActivity : ComponentActivity() {
         val lastLocation = (application as CoachMeApplication).locationProvider.getLastLocation()
         val userLatLng = lastLocation.value?: CAMPUS
         val email = database.getCurrentEmail()
+
+        // initially all sports are selected
+        sportsFilter = mutableStateOf(Sports.values().toList())
+        selectSportsHandler = SelectSportsActivity.getHandler(this)
 
         if (email.isEmpty()) {
             val errorMsg = "The coach list did not receive an email address.\nPlease return to the login page and try again."
@@ -70,6 +90,7 @@ class CoachesListActivity : ComponentActivity() {
             setContent {
                 var listOfCoaches by remember { mutableStateOf(listOf<UserInfo>()) }
 
+
                 // Proper way to handle result of a future in a Composable.
                 // This makes sure the listOfCoaches state is updated only ONCE, when the future is complete
                 // This is because the code in LaunchedEffect(true) will only be executed once, when the
@@ -88,95 +109,131 @@ class CoachesListActivity : ComponentActivity() {
 
                 CoachMeTheme {
                     Dashboard(title) {
-                        Column(modifier = it.fillMaxSize()) {
-                            LazyColumn {
-                                items(listOfCoaches) {user ->
-                                    UserInfoListItem(user, isViewingContacts)
-                                }
-                            }
-                        }
+                        CoachesList(it, listOfCoaches, isViewingContacts, sportsFilter)
                     }
                 }
             }
         }
     }
-}
 
-@Composable
-fun UserInfoListItem(user: UserInfo, isViewingContacts: Boolean) {
-    val context = LocalContext.current
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable {
-                if (isViewingContacts) {
-                    val displayChatIntent = Intent(context, ChatActivity::class.java)
-                    displayChatIntent.putExtra("toUserEmail", user.email)
-                    context.startActivity(displayChatIntent)
-                } else {
-                    val displayCoachIntent = Intent(context, ProfileActivity::class.java)
-                    displayCoachIntent.putExtra("email", user.email)
-                    displayCoachIntent.putExtra("isViewingCoach", true)
-                    context.startActivity(displayCoachIntent)
+    @Composable()
+    fun CoachesList(
+        modifier: Modifier,
+        listOfCoaches: List<UserInfo>,
+        isViewingContacts: Boolean,
+        sportsFilter: MutableState<List<Sports>>
+    ) {
+        val context = LocalContext.current
+
+        Box(modifier = modifier.fillMaxSize()) {
+            LazyColumn {
+                items(listOfCoaches) {user ->
+                    if (!Collections.disjoint(user.sports, sportsFilter.value)) {
+                        UserInfoListItem(user, isViewingContacts)
+                    }
                 }
             }
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .height(100.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // TODO: might be a good idea to merge the profile picture code used here and the one used in EditProfileActivity
-        Image(
-            painter = painterResource(id = R.drawable.ic_launcher_background),
-            contentDescription = "${user.firstName} ${user.lastName}'s profile picture",
-            modifier = Modifier
-                .size(80.dp)
-                .clip(CircleShape)
-                .border(2.dp, Color.Gray, CircleShape)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Column(
-            modifier = Modifier.fillMaxHeight(),
-            verticalArrangement = Arrangement.SpaceEvenly
-        ) {
-            Text(
-                text = "${user.firstName} ${user.lastName}",
-                style = MaterialTheme.typography.h6,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Row(
-                verticalAlignment = Alignment.CenterVertically
+            FloatingActionButton(
+                onClick = {
+//                    this@CoachesListActivity.sportsFilter.value =
+                    selectSportsHandler(
+                            SelectSportsActivity.getIntent(
+                                context = context,
+                                title = "Filter coaches by sport",
+                                initialValue = sportsFilter.value
+                            )).thenApply {sportsFilter.value = it }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+                    .testTag(FILTER),
+                backgroundColor = Purple200
             ) {
                 Icon(
-                    imageVector = Icons.Default.Place,
-                    tint = Color.Gray,
-                    contentDescription = "${user.firstName} ${user.lastName}'s location",
-                    modifier = Modifier.size(20.dp)
+                    imageVector = Default.Tune,
+                    contentDescription = "Filter nearby coaches by sport"
                 )
-                Spacer(modifier = Modifier.width(4.dp))
-                // Temporary, until we implement proper location handling
-                Text(
-                    text = user.address.name,
-                    color = Color.Gray,
-                    style = MaterialTheme.typography.body2,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                user.sports.map {
-                    Icon(
-                        imageVector = it.sportIcon,
-                        tint = Color.Gray,
-                        contentDescription = it.sportName,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                }
             }
         }
     }
-    Divider()
+
+    @Composable
+    fun UserInfoListItem(user: UserInfo, isViewingContacts: Boolean) {
+        val context = LocalContext.current
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    if (isViewingContacts) {
+                        val displayChatIntent = Intent(context, ChatActivity::class.java)
+                        displayChatIntent.putExtra("toUserEmail", user.email)
+                        context.startActivity(displayChatIntent)
+                    } else {
+                        val displayCoachIntent = Intent(context, ProfileActivity::class.java)
+                        displayCoachIntent.putExtra("email", user.email)
+                        displayCoachIntent.putExtra("isViewingCoach", true)
+                        context.startActivity(displayCoachIntent)
+                    }
+                }
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .height(100.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // TODO: might be a good idea to merge the profile picture code used here and the one used in EditProfileActivity
+            Image(
+                painter = painterResource(id = R.drawable.ic_launcher_background),
+                contentDescription = "${user.firstName} ${user.lastName}'s profile picture",
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .border(2.dp, Color.Gray, CircleShape)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(
+                modifier = Modifier.fillMaxHeight(),
+                verticalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Text(
+                    text = "${user.firstName} ${user.lastName}",
+                    style = MaterialTheme.typography.h6,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Default.Place,
+                        tint = Color.Gray,
+                        contentDescription = "${user.firstName} ${user.lastName}'s location",
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    // Temporary, until we implement proper location handling
+                    Text(
+                        text = user.address.name,
+                        color = Color.Gray,
+                        style = MaterialTheme.typography.body2,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    user.sports.map {
+                        Icon(
+                            imageVector = it.sportIcon,
+                            tint = Color.Gray,
+                            contentDescription = it.sportName,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
+                }
+            }
+        }
+        Divider()
+    }
 }
+


### PR DESCRIPTION
This PR adds a button in nearby coaches that enables the user to apply a filter by sports in the displayed list of coaches. Only the coaches having the selected sports as favorites are displayed when the filter is applied, allowing the user to quickly find the best coaching following his needs.

Conflicts with the LocationProvider were fixed and tests were added to CoachesListActivityTest.