### PR TITLE
Polish dark mode and overall details in the app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     implementation 'com.maxkeppeler.sheets-compose-dialogs:color:1.0.2'
     implementation 'com.maxkeppeler.sheets-compose-dialogs:calendar:1.0.2'
     implementation 'com.maxkeppeler.sheets-compose-dialogs:clock:1.0.2'
+    // Add material 3 API to be able to use material 3 theme for maxkeppeler sheets
+    implementation 'androidx.compose.material3:material3:1.2.0-alpha01'
     //noinspection GradleDependency
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     //noinspection GradleDependency

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,8 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
+    debugImplementation 'androidx.test:monitor:1.6.1'
+    debugImplementation 'androidx.test:core:1.5.0'
     //noinspection GradleDependency
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     //noinspection GradleDependency

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,8 @@ dependencies {
     implementation 'com.maxkeppeler.sheets-compose-dialogs:calendar:1.0.2'
     implementation 'com.maxkeppeler.sheets-compose-dialogs:clock:1.0.2'
     // Add material 3 API to be able to use material 3 theme for maxkeppeler sheets
-    implementation 'androidx.compose.material3:material3:1.2.0-alpha01'
+    // TODO: Add this dependencies when enabling dark mode for maxkeppeler sheets
+    // implementation 'androidx.compose.material3:material3:1.2.0-alpha01'
     //noinspection GradleDependency
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     //noinspection GradleDependency
@@ -94,8 +95,9 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
-    debugImplementation 'androidx.test:monitor:1.6.1'
-    debugImplementation 'androidx.test:core:1.5.0'
+    // TODO: Add those dependencies when enabling dark mode for maxkeppeler sheets
+    // debugImplementation 'androidx.test:monitor:1.6.1'
+    // debugImplementation 'androidx.test:core:1.5.0'
     //noinspection GradleDependency
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     //noinspection GradleDependency

--- a/app/src/androidTest/java/com/github/sdpcoachme/messaging/ChatActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/messaging/ChatActivityTest.kt
@@ -32,7 +32,6 @@ import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CHAT_BOX
 import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CHAT_FIELD
 import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CHAT_MESSAGE
 import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CONTACT_FIELD
-import com.github.sdpcoachme.profile.CoachesListActivity
 import com.github.sdpcoachme.profile.ProfileActivity
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -176,27 +175,6 @@ class ChatActivityTest {
                     hasExtra("isViewingCoach", true)
                 )
             )
-        }
-    }
-
-    @Test
-    fun backButtonReturnsToListedContactsWhenPressed() {
-        ActivityScenario.launch<ChatActivity>(personalChatDefaultIntent).use {
-            waitForLoading(it)
-
-            composeTestRule.onNodeWithTag(BACK)
-                .assertIsDisplayed()
-                .performClick()
-
-            Intents.intended(
-                allOf(
-                    hasComponent(CoachesListActivity::class.java.name),
-                    hasExtra("isViewingContacts", true)
-                )
-            )
-
-            composeTestRule.onNodeWithText("${UserInfoSamples.COACH_1.firstName} ${UserInfoSamples.COACH_1.lastName}")
-                .assertIsDisplayed()
         }
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/messaging/InAppNotifierTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/messaging/InAppNotifierTest.kt
@@ -14,6 +14,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
+import com.github.sdpcoachme.R
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.CoachMeTestApplication
 import com.github.sdpcoachme.data.UserInfoSamples
@@ -82,7 +83,8 @@ class InAppNotifierTest {
 
     @Test
     fun onMessageReceivedRedirectsToCoachesListActivityWhenChatIdIsNotSet() {
-        val intent = Intent(ApplicationProvider.getApplicationContext(), MapActivity::class.java)
+        val context = ApplicationProvider.getApplicationContext() as CoachMeApplication
+        val intent = Intent(context, MapActivity::class.java)
 
         ActivityScenario.launch<MapActivity>(intent).use {
             sendNotification("Title", "Body", "", "messaging")
@@ -90,10 +92,9 @@ class InAppNotifierTest {
 
             // Check if CoachesListActivity is opened
             // Intents.intended does not seem to work when clicking on a notification
-            // make sure "Contacts" is displayed in the header bar
             // TODO: would need to wait for the state to load before checking the UI...
             composeTestRule.onNodeWithTag(Dashboard.TestTags.BAR_TITLE).assertExists().assertIsDisplayed()
-            composeTestRule.onNodeWithTag(Dashboard.TestTags.BAR_TITLE).assert(hasText("Contacts"))
+            composeTestRule.onNodeWithTag(Dashboard.TestTags.BAR_TITLE).assert(hasText(context.getString(R.string.chats)))
 
             composeTestRule.onNodeWithText("${toUser.firstName} ${toUser.lastName}")
                 .assertIsDisplayed()
@@ -125,7 +126,8 @@ class InAppNotifierTest {
 
     @Test
     fun defaultNotificationIsShownIfOnlyNotificationTypeIsSet() {
-        val intent = Intent(ApplicationProvider.getApplicationContext(), MapActivity::class.java)
+        val context = ApplicationProvider.getApplicationContext() as CoachMeApplication
+        val intent = Intent(context, MapActivity::class.java)
 
         ActivityScenario.launch<MapActivity>(intent).use {
             sendNotification(null, null, null, "messaging")
@@ -136,7 +138,7 @@ class InAppNotifierTest {
             // Since the sender is not set, clicking on the notification should take the user to their contacts
             // TODO: would need to wait for the state to load before checking the UI...
             composeTestRule.onNodeWithTag(Dashboard.TestTags.BAR_TITLE).assertExists().assertIsDisplayed()
-            composeTestRule.onNodeWithTag(Dashboard.TestTags.BAR_TITLE).assert(hasText("Contacts"))
+            composeTestRule.onNodeWithTag(Dashboard.TestTags.BAR_TITLE).assert(hasText(context.getString(R.string.chats)))
 
             composeTestRule.onNodeWithText("${toUser.firstName} ${toUser.lastName}")
                 .assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -212,7 +212,7 @@ open class CoachesListActivityTest {
         @Test
         fun dashboardHasRightTitleOnContactsList() {
             val title = (InstrumentationRegistry.getInstrumentation()
-                .targetContext.applicationContext as CoachMeApplication).getString(R.string.contacts)
+                .targetContext.applicationContext as CoachMeApplication).getString(R.string.chats)
             composeTestRule.onNodeWithTag(BAR_TITLE).assertExists().assertIsDisplayed()
             composeTestRule.onNodeWithTag(BAR_TITLE).assert(hasText(title))
         }

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/ContactsListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/ContactsListActivityTest.kt
@@ -147,7 +147,7 @@ class ContactsListTest {
     fun dashboardHasRightTitleOnContactsList() {
         startActivity()
         val title = (InstrumentationRegistry.getInstrumentation()
-            .targetContext.applicationContext as CoachMeApplication).getString(R.string.contacts)
+            .targetContext.applicationContext as CoachMeApplication).getString(R.string.chats)
         composeTestRule.onNodeWithTag(BAR_TITLE).assertExists()
             .assertIsDisplayed()
         composeTestRule.onNodeWithTag(BAR_TITLE).assert(hasText(title))

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/ProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/ProfileActivityTest.kt
@@ -295,7 +295,7 @@ class ProfileActivityTest {
             composeTestRule.onNodeWithTag(SPORTS, useUnmergedTree = true).performClick()
 
             for (rowTag in ROW_TEXT_LIST) {
-                composeTestRule.onNodeWithTag(rowTag.ROW, useUnmergedTree = true).performClick()
+                composeTestRule.onNodeWithTag(rowTag.ROW, useUnmergedTree = true).performScrollTo().performClick()
             }
             composeTestRule.onNodeWithTag(SelectSportsActivity.TestTags.Buttons.DONE, useUnmergedTree = true).performClick()
 
@@ -317,7 +317,7 @@ class ProfileActivityTest {
             composeTestRule.onNodeWithTag(SPORTS, useUnmergedTree = true).performClick()
 
             for (rowTag in ROW_TEXT_LIST) {
-                composeTestRule.onNodeWithTag(rowTag.ROW, useUnmergedTree = true).performClick()
+                composeTestRule.onNodeWithTag(rowTag.ROW, useUnmergedTree = true).performScrollTo().performClick()
             }
             composeTestRule.onNodeWithTag(SelectSportsActivity.TestTags.Buttons.CANCEL, useUnmergedTree = true).performClick()
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/SelectSportsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/SelectSportsActivityTest.kt
@@ -64,7 +64,10 @@ open class SelectSportsActivityTest {
             composeTestRule.onNodeWithTag(DONE).assertIsDisplayed()
             composeTestRule.onNodeWithTag(CANCEL).assertIsDisplayed()
             ROW_TEXT_LIST.forEach {
-                composeTestRule.onNodeWithTag(it.ICON, useUnmergedTree = true).assertDoesNotExist()
+                composeTestRule.onNodeWithTag(it.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                composeTestRule.onNodeWithTag(it.ICON, useUnmergedTree = true)
+                    .assertDoesNotExist()
             }
         }
     }
@@ -78,20 +81,31 @@ open class SelectSportsActivityTest {
             title = title,
             initialValue = initialValue
         )
-        ActivityScenario.launch<EditTextActivity>(intent).use {
+        ActivityScenario.launch<SelectSportsActivity>(intent).use {
             for (sport in Sports.values()) {
+                val tags = TestTags.ListRowTag(sport)
                 if (sport in initialValue) {
-                    composeTestRule.onNodeWithTag(TestTags.ListRowTag(sport).ICON, useUnmergedTree = true).assertIsDisplayed()
+                    composeTestRule.onNodeWithTag(tags.ROW, useUnmergedTree = true)
+                        .performScrollTo()
+                    composeTestRule.onNodeWithTag(tags.ICON, useUnmergedTree = true)
+                        .assertIsDisplayed()
                 } else {
-                    composeTestRule.onNodeWithTag(TestTags.ListRowTag(sport).ICON, useUnmergedTree = true).assertDoesNotExist()
+                    composeTestRule.onNodeWithTag(tags.ROW, useUnmergedTree = true)
+                        .performScrollTo()
+                    composeTestRule.onNodeWithTag(tags.ICON, useUnmergedTree = true)
+                        .assertDoesNotExist()
                 }
             }
             composeTestRule.onNodeWithTag(TITLE).assertIsDisplayed().assertTextEquals(title)
             composeTestRule.onNodeWithTag(DONE).assertIsDisplayed()
             composeTestRule.onNodeWithTag(CANCEL).assertIsDisplayed()
             for (sport in Sports.values()) {
-                composeTestRule.onNodeWithTag(TestTags.ListRowTag(sport).ROW).assertIsDisplayed()
-                composeTestRule.onNodeWithTag(TestTags.ListRowTag(sport).ROW).assertTextEquals(sport.sportName)
+                val tags = TestTags.ListRowTag(sport)
+                composeTestRule.onNodeWithTag(tags.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                composeTestRule.onNodeWithTag(tags.TEXT, useUnmergedTree = true)
+                    .assertIsDisplayed()
+                    .assertTextEquals(sport.sportName)
             }
         }
     }
@@ -100,10 +114,15 @@ open class SelectSportsActivityTest {
     fun tickIconsDisplayedAfterClick() {
         ActivityScenario.launch<SelectSportsActivity>(launchSelectSports).use {
             ROW_TEXT_LIST.forEach {
-                composeTestRule.onNodeWithTag(it.ROW).performClick()
+                composeTestRule.onNodeWithTag(it.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                    .performClick()
             }
             ROW_TEXT_LIST.forEach {
-                composeTestRule.onNodeWithTag(it.ICON, useUnmergedTree = true).assertIsDisplayed()
+                composeTestRule.onNodeWithTag(it.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                composeTestRule.onNodeWithTag(it.ICON, useUnmergedTree = true)
+                    .assertIsDisplayed()
             }
         }
     }
@@ -112,13 +131,20 @@ open class SelectSportsActivityTest {
     fun tickIconsDisappearAfterSecondClick() {
         ActivityScenario.launch<SelectSportsActivity>(launchSelectSports).use {
             ROW_TEXT_LIST.forEach {
-                composeTestRule.onNodeWithTag(it.ROW).performClick()
+                composeTestRule.onNodeWithTag(it.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                    .performClick()
             }
             ROW_TEXT_LIST.forEach {
-                composeTestRule.onNodeWithTag(it.ROW).performClick()
+                composeTestRule.onNodeWithTag(it.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                    .performClick()
             }
             ROW_TEXT_LIST.forEach {
-                composeTestRule.onNodeWithTag(it.ICON, useUnmergedTree = true).assertDoesNotExist()
+                composeTestRule.onNodeWithTag(it.ROW, useUnmergedTree = true)
+                    .performScrollTo()
+                composeTestRule.onNodeWithTag(it.ICON, useUnmergedTree = true)
+                    .assertDoesNotExist()
             }
         }
     }

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/CreateEventActivityTest.kt
@@ -6,8 +6,6 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -24,7 +22,6 @@ import com.github.sdpcoachme.data.schedule.EventType
 import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.location.autocomplete.MockAddressAutocompleteHandler
 import com.github.sdpcoachme.profile.SelectSportsActivity
-import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.CANCEL
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.COLOR_BOX
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_DATE
 import com.github.sdpcoachme.schedule.CreateEventActivity.TestTags.Clickables.Companion.END_TIME
@@ -60,7 +57,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
@@ -282,10 +278,10 @@ class CreateEventActivityTest {
                 .performClick() // launches SelectSportsActivity
 
             val runTag = SelectSportsActivity.TestTags.ListRowTag(Sports.RUNNING).ROW
-            composeTestRule.onNodeWithTag(runTag, useUnmergedTree = true).performClick()   // unchoose running
+            composeTestRule.onNodeWithTag(runTag, useUnmergedTree = true).performScrollTo().performClick()   // unchoose running
 
             val swimTag = SelectSportsActivity.TestTags.ListRowTag(Sports.SWIMMING).ROW
-            composeTestRule.onNodeWithTag(swimTag, useUnmergedTree = true).performClick()   // choose swimming
+            composeTestRule.onNodeWithTag(swimTag, useUnmergedTree = true).performScrollTo().performClick()   // choose swimming
 
             composeTestRule.onNodeWithTag(SelectSportsActivity.TestTags.Buttons.DONE, useUnmergedTree = true).performClick() // go back to CreateEventActivity
 
@@ -305,10 +301,10 @@ class CreateEventActivityTest {
                 .performClick() // launches SelectSportsActivity
 
             val runTag = SelectSportsActivity.TestTags.ListRowTag(Sports.RUNNING).ROW
-            composeTestRule.onNodeWithTag(runTag, useUnmergedTree = true).performClick()   // unchoose running
+            composeTestRule.onNodeWithTag(runTag, useUnmergedTree = true).performScrollTo().performClick()   // unchoose running
 
             val swimTag = SelectSportsActivity.TestTags.ListRowTag(Sports.SWIMMING).ROW
-            composeTestRule.onNodeWithTag(swimTag, useUnmergedTree = true).performClick()   // choose swimming
+            composeTestRule.onNodeWithTag(swimTag, useUnmergedTree = true).performScrollTo().performClick()   // choose swimming
 
             composeTestRule.onNodeWithTag(SelectSportsActivity.TestTags.Buttons.CANCEL, useUnmergedTree = true).performClick() // go back to CreateEventActivity
 
@@ -373,30 +369,21 @@ class CreateEventActivityTest {
     }
 
     @Test
-    fun addPrivateEventWithValidInfosRedirectsToSchedule() {
+    fun addPrivateEventWithValidInfosFocusWorks() {
         defaultIntent.putExtra("eventType", EventType.PRIVATE.eventTypeName)
 
         ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
-            fillAndCheckFocus(defaultEvent.name, EVENT_NAME)
-            fillAndCheckFocus(defaultEvent.description, DESCRIPTION)
-
             val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            fillAndCheckFocus(defaultEvent.name, EVENT_NAME)
             device.waitForIdle()
-            composeTestRule.onNodeWithTag(SAVE)
-                .assertExists()
-                .performClick()
-
+            fillAndCheckFocus(defaultEvent.description, DESCRIPTION)
             device.waitForIdle()
-
-            // Check that we are redirected to Schedule (onNodeWithText because return to schedule waits for future)
-            composeTestRule.onNodeWithText("Schedule", substring = true, useUnmergedTree = true)
-                .assertIsDisplayed()
         }
     }
 
 
     @Test
-    fun addGroupEventWithValidInfosRedirectsToSchedule() {
+    fun addGroupEventWithValidInfosFocusWorks() {
         defaultIntent.putExtra("eventType", EventType.GROUP.eventTypeName)
 
         ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
@@ -408,38 +395,6 @@ class CreateEventActivityTest {
             device.waitForIdle()
             fillAndCheckFocus(defaultEvent.description, DESCRIPTION)
             device.waitForIdle()
-
-            composeTestRule.onNodeWithTag(SAVE)
-                .assertExists()
-                .performClick()
-
-            // Check that we are redirected to Schedule (onNodeWithText because return to schedule waits for future)
-            composeTestRule.onNodeWithText("Schedule", substring = true, useUnmergedTree = true)
-                .assertIsDisplayed()
-        }
-    }
-
-    @Test
-    fun cancelPrivateEventCorrectlyRedirectsToSchedule() {
-        defaultIntent.putExtra("eventType", EventType.PRIVATE.eventTypeName)
-
-        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
-            composeTestRule.onNodeWithTag(CANCEL)
-                .performClick()
-
-            intended(hasComponent(ScheduleActivity::class.java.name))
-        }
-    }
-
-    @Test
-    fun cancelGroupEventCorrectlyRedirectsToSchedule() {
-        defaultIntent.putExtra("eventType", EventType.GROUP.eventTypeName)
-
-        ActivityScenario.launch<CreateEventActivity>(defaultIntent).use {
-            composeTestRule.onNodeWithTag(CANCEL)
-                .performClick()
-
-            intended(hasComponent(ScheduleActivity::class.java.name))
         }
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/schedule/ScheduleActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/schedule/ScheduleActivityTest.kt
@@ -16,7 +16,6 @@ import com.github.sdpcoachme.data.schedule.EventType
 import com.github.sdpcoachme.data.schedule.ShownEvent
 import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.Buttons.Companion.GO_TO_LOGIN_BUTTON
-import com.github.sdpcoachme.errorhandling.IntentExtrasErrorHandlerActivity.TestTags.TextFields.Companion.ERROR_MESSAGE_FIELD
 import com.github.sdpcoachme.location.MapActivity
 import com.github.sdpcoachme.schedule.ScheduleActivity.TestTags.Buttons.Companion.ADD_EVENT_BUTTON
 import com.github.sdpcoachme.schedule.ScheduleActivity.TestTags.Buttons.Companion.ADD_GROUP_EVENT_BUTTON
@@ -82,15 +81,6 @@ class ScheduleActivityTest {
             initiallyDisplayed.forEach { tag ->
                 composeTestRule.onNodeWithTag(tag, useUnmergedTree = true).assertExists()
             }
-        }
-    }
-
-    @Test
-    fun errorPageIsShownWhenScheduleIsLaunchedWithEmptyCurrentEmail() {
-        store.setCurrentEmail("")
-        ActivityScenario.launch<ScheduleActivity>(defaultIntent).use {
-            composeTestRule.onNodeWithTag(GO_TO_LOGIN_BUTTON).assertIsDisplayed()
-            composeTestRule.onNodeWithTag(ERROR_MESSAGE_FIELD).assertIsDisplayed()
         }
     }
 
@@ -306,9 +296,9 @@ class ScheduleActivityTest {
             composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()
             composeTestRule.onNodeWithTag(RIGHT_ARROW_BUTTON).assertExists()
             composeTestRule.onNodeWithTag(RIGHT_ARROW_BUTTON).performClick()    // switch 1 week forward
-            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.plusDays(7).format(formatter)} - \n${currentMonday.plusDays(13).format(formatter)}")
+            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.plusDays(7).format(formatter)}\n${currentMonday.plusDays(13).format(formatter)}")
             composeTestRule.onNodeWithTag(RIGHT_ARROW_BUTTON).performClick()    // switch 1 week forward
-            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.plusDays(14).format(formatter)} - \n${currentMonday.plusDays(20).format(formatter)}")
+            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.plusDays(14).format(formatter)}\n${currentMonday.plusDays(20).format(formatter)}")
         }
     }
 
@@ -319,9 +309,9 @@ class ScheduleActivityTest {
             composeTestRule.onNodeWithTag(BASIC_SCHEDULE).assertExists()
             composeTestRule.onNodeWithTag(LEFT_ARROW_BUTTON).assertExists()
             composeTestRule.onNodeWithTag(LEFT_ARROW_BUTTON).performClick()   // switch 1 week backward
-            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.minusDays(7).format(formatter)} - \n${currentMonday.minusDays(1).format(formatter)}")
+            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.minusDays(7).format(formatter)}\n${currentMonday.minusDays(1).format(formatter)}")
             composeTestRule.onNodeWithTag(LEFT_ARROW_BUTTON).performClick()  // switch 1 week backward
-            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.minusDays(14).format(formatter)} - \n${currentMonday.minusDays(8).format(formatter)}")
+            composeTestRule.onNodeWithTag(CURRENT_WEEK_TEXT_FIELD).assertTextContains("${currentMonday.minusDays(14).format(formatter)}\n${currentMonday.minusDays(8).format(formatter)}")
         }
     }
 

--- a/app/src/androidTest/java/com/github/sdpcoachme/ui/DashboardTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/ui/DashboardTest.kt
@@ -154,6 +154,7 @@ class DashboardTest {
         tag: String,
         intentMatcher: Matcher<Intent>
     ) {
+        composeTestRule.onNodeWithTag(HAMBURGER_MENU).performClick()
         composeTestRule.onNodeWithTag(tag).performClick()
         intended(intentMatcher)
     }

--- a/app/src/main/java/com/github/sdpcoachme/auth/SignupActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/auth/SignupActivity.kt
@@ -7,10 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Button
-import androidx.compose.material.Switch
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,10 +18,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.CoachMeApplication
+import com.github.sdpcoachme.data.Address
 import com.github.sdpcoachme.data.Sports
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.database.CachingStore
-import com.github.sdpcoachme.data.Address
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.location.MapActivity
 import com.github.sdpcoachme.location.autocomplete.AddressAutocompleteHandler
@@ -81,7 +78,11 @@ class SignupActivity : ComponentActivity() {
             }
 
             CoachMeTheme {
-                AccountForm(email)
+                Surface(
+                    color = MaterialTheme.colors.background,
+                ) {
+                    AccountForm(email)
+                }
             }
         }
     }
@@ -96,15 +97,16 @@ class SignupActivity : ComponentActivity() {
         var isCoach by remember { mutableStateOf(false) }
         val focusManager = LocalFocusManager.current
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize(),
             verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             TextField(
                 modifier = Modifier.testTag(TestTags.TextFields.FIRST_NAME),
                 value = firstName,
                 onValueChange = { firstName = it },
-                label = { Text("First Name") },
+                label = { Text("First name") },
                 maxLines = 1,
                 keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
                 keyboardActions = KeyboardActions(
@@ -115,7 +117,7 @@ class SignupActivity : ComponentActivity() {
                 modifier = Modifier.testTag(TestTags.TextFields.LAST_NAME),
                 value = lastName,
                 onValueChange = { lastName = it },
-                label = { Text("Last Name") },
+                label = { Text("Last name") },
                 maxLines = 1,
                 keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
                 keyboardActions = KeyboardActions(
@@ -138,7 +140,9 @@ class SignupActivity : ComponentActivity() {
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("I would like to be a coach")
+                Text(
+                    text = "I would like to be a coach"
+                )
                 Spacer(Modifier.width(16.dp))
                 Switch(
                     checked = isCoach,

--- a/app/src/main/java/com/github/sdpcoachme/data/Sports.kt
+++ b/app/src/main/java/com/github/sdpcoachme/data/Sports.kt
@@ -5,9 +5,23 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class Sports(val sportName: String, val sportIcon: ImageVector) {
-    SKI("Ski", Icons.Default.DownhillSkiing),
-    TENNIS("Tennis", Icons.Default.SportsTennis),
+    BASKETBALL("Basketball", Icons.Default.SportsBasketball),
+    CLIMBING("Climbing", Icons.Default.Terrain),
+    CYCLING("Cycling", Icons.Default.DirectionsBike),
+    FOOTBALL("Football", Icons.Default.SportsSoccer),
+    GOLF("Golf", Icons.Default.GolfCourse),
+    GYMNASTICS("Gymnastics", Icons.Default.SportsGymnastics),
+    HIKING("Hiking", Icons.Default.Hiking),
+    HOCKEY("Hockey", Icons.Default.SportsHockey),
+    KAYAKING("Kayaking", Icons.Default.Kayaking),
+    ROWING("Rowing", Icons.Default.Rowing),
     RUNNING("Running", Icons.Default.DirectionsRun),
+    SKI("Ski", Icons.Default.DownhillSkiing),
+    SNOWBOARD("Snowboard", Icons.Default.Snowboarding),
+    SURFING("Surfing", Icons.Default.Surfing),
     SWIMMING("Swimming", Icons.Default.Pool),
+    TENNIS("Tennis", Icons.Default.SportsTennis),
+    VOLLEYBALL("Volleyball", Icons.Default.SportsVolleyball),
     WORKOUT("Workout", Icons.Default.FitnessCenter),
+    YOGA("Yoga", Icons.Default.SelfImprovement),
 }

--- a/app/src/main/java/com/github/sdpcoachme/database/CachingStore.kt
+++ b/app/src/main/java/com/github/sdpcoachme/database/CachingStore.kt
@@ -731,7 +731,7 @@ class CachingStore(private val wrappedDatabase: Database,
      */
     fun setCurrentEmail(email: String): CompletableFuture<Void> {
         currentEmail = email
-        return completedFuture(null)
+        return storeLocalData()
     }
 
     /**

--- a/app/src/main/java/com/github/sdpcoachme/errorhandling/IntentExtrasErrorHandlerActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/errorhandling/IntentExtrasErrorHandlerActivity.kt
@@ -6,6 +6,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -47,7 +49,11 @@ class IntentExtrasErrorHandlerActivity : ComponentActivity() {
 
         setContent {
             CoachMeTheme {
-                IntentExtrasErrorScreen(errorMsg)
+                Surface(
+                    color = MaterialTheme.colors.background
+                ) {
+                    IntentExtrasErrorScreen(errorMsg)
+                }
             }
         }
     }
@@ -71,7 +77,7 @@ class IntentExtrasErrorHandlerActivity : ComponentActivity() {
                     val intent = Intent(context, LoginActivity::class.java)
                     startActivity(intent)
                 }) {
-                    Text(text = "Return to login page")
+                    Text(text = "RETURN TO LOGIN PAGE")
                 }
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventDetailsActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventDetailsActivity.kt
@@ -50,6 +50,8 @@ import com.github.sdpcoachme.groupevent.GroupEventDetailsActivity.TestTags.Tabs.
 import com.github.sdpcoachme.groupevent.GroupEventDetailsActivity.TestTags.Tabs.Companion.PARTICIPANTS
 import com.github.sdpcoachme.messaging.ChatActivity
 import com.github.sdpcoachme.profile.ProfileActivity
+import com.github.sdpcoachme.ui.ImageData
+import com.github.sdpcoachme.ui.SmallListItem
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import kotlinx.coroutines.future.await
 import java.time.LocalDateTime
@@ -57,6 +59,9 @@ import java.time.Month
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Activity that displays the details of a group event.
+ */
 class GroupEventDetailsActivity : ComponentActivity() {
 
     class TestTags {
@@ -515,7 +520,6 @@ private fun IconTextRow(
     }
 }
 
-// TODO: might be a way to modularize with UserInfoListItem from CoachesListActivity
 /**
  * Composable that displays a row with a user's profile picture and name.
  */
@@ -524,33 +528,14 @@ fun SmallUserInfoListItem(
     userInfo: UserInfo,
     onClick: (() -> Unit)? = null
 ) {
-    Row(
-        modifier =
-        if (onClick != null) {
-            Modifier.clickable(onClick = onClick)
-        } else {
-            Modifier
-        }
-            .padding(10.dp)
-            .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Image(
+    SmallListItem(
+        image = ImageData(
             painter = painterResource(id = R.drawable.ic_launcher_background),
-            contentDescription = "${userInfo.firstName} ${userInfo.lastName}'s profile picture",
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .border(2.dp, Color.Gray, CircleShape)
-                .padding(0.dp, 0.dp, 0.dp, 0.dp)
-        )
-        Spacer(modifier = Modifier.width(10.dp))
-        Text(
-            text = "${userInfo.firstName} ${userInfo.lastName}",
-            style = MaterialTheme.typography.body1
-        )
-    }
-    Divider()
+            contentDescription = "${userInfo.firstName} ${userInfo.lastName}'s profile picture"
+        ),
+        title = "${userInfo.firstName} ${userInfo.lastName}",
+        onClick = onClick
+    )
 }
 
 // Needed because of https://stackoverflow.com/questions/68847231/jetpack-compose-how-to-disable-floatingaction-button

--- a/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventDetailsActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventDetailsActivity.kt
@@ -146,51 +146,61 @@ class GroupEventDetailsActivity : ComponentActivity() {
             }
 
             CoachMeTheme {
-                Scaffold(
-                    topBar = {
-                        TopAppBar(
-                            title = {
-                                Text("Event details", modifier = Modifier.testTag(TITLE))
-                            },
-                            navigationIcon = {
-                                IconButton(
-                                    onClick = { finish() },
-                                    modifier = Modifier.testTag(BACK)
-                                ) {
-                                    Icon(Icons.Filled.ArrowBack, "Back")
-                                }
-                            }
-                        )
-                    }
-                ) { padding ->
-                    Column(
-                        modifier = Modifier.padding(padding)
-                    ) {
-                        if (groupEvent != null && currentUser != null
-                            && organizer != null && participants != null) {
-                            GroupEventDetailsLayout(
-                                groupEvent!!,
-                                organizer!!,
-                                currentUser!!,
-                                participants!!,
-                                onJoinEventClick = {
-                                    store.registerForGroupEvent(groupEvent!!.groupEventId).thenAccept {
-                                        // Will trigger the launched effect to refresh the UI
-                                        refreshUI = !refreshUI
-                                        // Tell the user that they have joined the event
-                                        val toast = Toast.makeText(
-                                            this@GroupEventDetailsActivity,
-                                            "You have succesfully joined the event!",
-                                            Toast.LENGTH_SHORT
-                                        )
-                                        toast.show()
-                                        // Notifying tests is necessary here since the launched effect
-                                        // is not triggered in the tests for some weird reason
-                                        stateUpdated.complete(null)
+                Surface(
+                    color = MaterialTheme.colors.background
+                ) {
+                    Scaffold(
+                        topBar = {
+                            TopAppBar(
+                                title = {
+                                    Text("Event details", modifier = Modifier.testTag(TITLE))
+                                },
+                                navigationIcon = {
+                                    IconButton(
+                                        onClick = { finish() },
+                                        modifier = Modifier.testTag(BACK)
+                                    ) {
+                                        Icon(Icons.Filled.ArrowBack, "Back")
                                     }
-                                    // TODO: print something if the registration fails ?
                                 }
                             )
+                        }
+                    ) { padding ->
+                        Surface(
+                            color = MaterialTheme.colors.background
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(padding)
+                            ) {
+                                if (groupEvent != null && currentUser != null
+                                    && organizer != null && participants != null
+                                ) {
+                                    GroupEventDetailsLayout(
+                                        groupEvent!!,
+                                        organizer!!,
+                                        currentUser!!,
+                                        participants!!,
+                                        onJoinEventClick = {
+                                            store.registerForGroupEvent(groupEvent!!.groupEventId)
+                                                .thenAccept {
+                                                    // Will trigger the launched effect to refresh the UI
+                                                    refreshUI = !refreshUI
+                                                    // Tell the user that they have joined the event
+                                                    val toast = Toast.makeText(
+                                                        this@GroupEventDetailsActivity,
+                                                        "You have succesfully joined the event!",
+                                                        Toast.LENGTH_SHORT
+                                                    )
+                                                    toast.show()
+                                                    // Notifying tests is necessary here since the launched effect
+                                                    // is not triggered in the tests for some weird reason
+                                                    stateUpdated.complete(null)
+                                                }
+                                            // TODO: print something if the registration fails ?
+                                        }
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -282,7 +292,9 @@ fun GroupEventDetailsLayout(
                 ClickableText(
                     modifier = Modifier.testTag(ORGANIZER_NAME),
                     text = AnnotatedString("${organizer.firstName} ${organizer.lastName}"),
-                    style = MaterialTheme.typography.body1,
+                    style = MaterialTheme.typography.body1.copy(
+                        color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+                    ),
                     onClick = {
                         // Open organizer profile
                         // If the organizer is the current user, open the profile activity, but not in edit mode
@@ -506,7 +518,9 @@ private fun IconTextRow(
             ClickableText(
                 modifier = Modifier.testTag(tag),
                 text = AnnotatedString(text),
-                style = MaterialTheme.typography.body1,
+                style = MaterialTheme.typography.body1.copy(
+                    color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+                ),
                 onClick = { onClick() }
             )
         } else {

--- a/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventDetailsActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventDetailsActivity.kt
@@ -275,8 +275,8 @@ fun GroupEventDetailsLayout(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.End
             ) {
-                Spacer(modifier = Modifier.width(10.dp))
                 Box(Modifier.width(70.dp)) { WeatherView(weatherState, eventStart.toLocalDate()) }
+                Spacer(modifier = Modifier.width(10.dp))
                 DayBox(eventStart.dayOfMonth, eventStart.month)
             }
             Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventsListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventsListActivity.kt
@@ -37,6 +37,9 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.CompletableFuture
 
+/**
+ * The activity that displays the list of group events.
+ */
 class GroupEventsListActivity : ComponentActivity() {
 
     class TestTags {
@@ -134,6 +137,9 @@ class GroupEventsListActivity : ComponentActivity() {
     }
 }
 
+/**
+ * A group event item in the list of group events.
+ */
 @Composable
 fun GroupEventItem(
     groupEvent: GroupEvent,

--- a/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventsListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/groupevent/GroupEventsListActivity.kt
@@ -30,8 +30,8 @@ import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.groupevent.GroupEventsListActivity.TestTags.Tabs.Companion.ALL
 import com.github.sdpcoachme.groupevent.GroupEventsListActivity.TestTags.Tabs.Companion.MY_EVENTS
 import com.github.sdpcoachme.ui.*
-import com.github.sdpcoachme.ui.theme.CoachMeTheme
-import com.github.sdpcoachme.ui.theme.DarkOrange
+import com.github.sdpcoachme.ui.theme.label
+import com.github.sdpcoachme.ui.theme.onLabel
 import kotlinx.coroutines.future.await
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -103,32 +103,33 @@ class GroupEventsListActivity : ComponentActivity() {
                     throw IllegalStateException("Unknown tab ${selectedTab.tag}")
             }
 
-            CoachMeTheme {
-                Dashboard(
-                    title = "Group events",
-                    noElevation = true,
+            Dashboard(
+                title = "Group events",
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize()
                 ) {
-                    Column(
-                        modifier = Modifier.fillMaxSize()
+                    TabRow(
+                        selectedTabIndex = selectedTabIndex,
+                        backgroundColor = MaterialTheme.colors.background,
+                        contentColor = MaterialTheme.colors.primary
                     ) {
-                        TabRow(
-                            selectedTabIndex = selectedTabIndex
-                        ) {
-                            tabs.forEachIndexed { index, tabItem ->
-                                Tab(
-                                    modifier = Modifier.testTag(tabItem.tag),
-                                    text = { Text(tabItem.title) },
-                                    selected = selectedTabIndex == index,
-                                    onClick = { selectedTabIndex = index }
-                                )
-                            }
+                        tabs.forEachIndexed { index, tabItem ->
+                            Tab(
+                                modifier = Modifier.testTag(tabItem.tag),
+                                text = { Text(tabItem.title) },
+                                selected = selectedTabIndex == index,
+                                onClick = { selectedTabIndex = index },
+                                selectedContentColor = MaterialTheme.colors.primary,
+                                unselectedContentColor = Color.Gray,
+                            )
                         }
-                        LazyColumn {
-                            items(displayedGroupEvents) { groupEvent ->
-                                GroupEventItem(
-                                    groupEvent = groupEvent
-                                )
-                            }
+                    }
+                    LazyColumn {
+                        items(displayedGroupEvents) { groupEvent ->
+                            GroupEventItem(
+                                groupEvent = groupEvent
+                            )
                         }
                     }
                 }
@@ -201,8 +202,8 @@ fun GroupEventItem(
                         icon = Icons.Default.History,
                         contentDescription = "Event already took place"
                     ),
-                    backgroundColor = DarkOrange,
-                    contentColor = Color.White
+                    backgroundColor = MaterialTheme.colors.label,
+                    contentColor = MaterialTheme.colors.onLabel
                 )
             } else if (groupEvent.participants.size >= groupEvent.maxParticipants) {
                 Label(
@@ -212,8 +213,8 @@ fun GroupEventItem(
                         icon = Icons.Default.EventBusy,
                         contentDescription = "Event is fully booked"
                     ),
-                    backgroundColor = DarkOrange,
-                    contentColor = Color.White
+                    backgroundColor = MaterialTheme.colors.label,
+                    contentColor = MaterialTheme.colors.onLabel
                 )
             }
         },

--- a/app/src/main/java/com/github/sdpcoachme/location/MapActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/location/MapActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.CoachMeApplication
+import com.github.sdpcoachme.R
 import com.github.sdpcoachme.data.UserInfo
 import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.location.MapActivity.TestTags.Companion.MAP
@@ -28,10 +29,10 @@ import com.github.sdpcoachme.location.provider.FusedLocationProvider.Companion.C
 import com.github.sdpcoachme.location.provider.LocationProvider
 import com.github.sdpcoachme.profile.ProfileActivity
 import com.github.sdpcoachme.ui.Dashboard
-import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.maps.android.compose.*
 import kotlinx.coroutines.future.await
 import java.util.concurrent.CompletableFuture
@@ -89,15 +90,13 @@ class MapActivity : ComponentActivity() {
         // Note: this is absolutely not scalable, but we can change this later on.
         val futureUsers = store.getAllUsers().thenApply { users -> users.filter { it.coach } }
         setContent {
-            CoachMeTheme {
-                Dashboard {
-                    Map(
-                        modifier = it,
-                        lastUserLocation = locationProvider.getLastLocation(),
-                        futureCoachesToDisplay = futureUsers,
-                        markerLoading = markerLoading,
-                        mapLoading = mapLoading)
-                }
+            Dashboard {
+                Map(
+                    modifier = it,
+                    lastUserLocation = locationProvider.getLastLocation(),
+                    futureCoachesToDisplay = futureUsers,
+                    markerLoading = markerLoading,
+                    mapLoading = mapLoading)
             }
         }
     }
@@ -140,7 +139,8 @@ fun Map(
         cameraPositionState = cameraPositionState,
         properties = MapProperties(
             isMyLocationEnabled = lastUserLocation.value != null,
-            mapType = MapType.NORMAL
+            mapType = MapType.NORMAL,
+            mapStyleOptions = if (MaterialTheme.colors.isLight) null else MapStyleOptions.loadRawResourceStyle(context, R.raw.google_maps_dark_theme),
         ),
         onMapLoaded = {
             // For testing purposes, we need to know when the map is ready

--- a/app/src/main/java/com/github/sdpcoachme/messaging/ChatActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/messaging/ChatActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
@@ -27,7 +28,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.data.GroupEvent
 import com.github.sdpcoachme.data.UserInfo
@@ -44,9 +44,8 @@ import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CHAT_BOX
 import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CHAT_FIELD
 import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CHAT_MESSAGE
 import com.github.sdpcoachme.messaging.ChatActivity.TestTags.Companion.CONTACT_FIELD
-import com.github.sdpcoachme.profile.CoachesListActivity
 import com.github.sdpcoachme.profile.ProfileActivity
-import com.github.sdpcoachme.ui.theme.Purple500
+import com.github.sdpcoachme.ui.theme.*
 import kotlinx.coroutines.future.await
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -146,13 +145,11 @@ class ChatActivity : ComponentActivity() {
             })
 
             setContent {
-
-                ChatView(
-                    chatId,
-                    contact,
-                    stateLoading,
-                    isGroupChat
-                )
+                CoachMeTheme {
+                    Surface(color = MaterialTheme.colors.background) {
+                        ChatView(chatId, contact, stateLoading, isGroupChat)
+                    }
+                }
             }
         }
     }
@@ -193,31 +190,34 @@ class ChatActivity : ComponentActivity() {
             stateLoading.complete(null)
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxHeight()
-        ) {
-
-            ContactField(toUser, chatId, isGroupChat, groupEvent)
-
-            ChatBoxContainer(
-                chat = chat,
-                currentUserEmail = currentUserEmail,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .weight(1f)
-                    .testTag(CHAT_BOX.CONTAINER)
-            )
-
-            ChatField(
-                currentUserEmail = currentUserEmail,
-                chat = chat,
-                onSend = {
-                    store.getChat(chatId).thenAccept { chat = it }
-                },
-                isGroupChat,
-                groupEvent,
-            )
+        Scaffold(
+            topBar = {
+                ContactField(toUser, chatId, isGroupChat, groupEvent)
+            }
+        ) { padding ->
+            Surface(color = MaterialTheme.colors.background) {
+                Column(
+                    modifier = Modifier.padding(padding)
+                ) {
+                    ChatBoxContainer(
+                        chat = chat,
+                        currentUserEmail = currentUserEmail,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .weight(1f)
+                            .testTag(CHAT_BOX.CONTAINER)
+                    )
+                    ChatField(
+                        currentUserEmail = currentUserEmail,
+                        chat = chat,
+                        onSend = {
+                            store.getChat(chatId).thenAccept { chat = it }
+                        },
+                        isGroupChat,
+                        groupEvent,
+                    )
+                }
+            }
         }
     }
 
@@ -232,13 +232,9 @@ class ChatActivity : ComponentActivity() {
         groupEvent: GroupEvent
     ) {
         val context = LocalContext.current
-        Row(
-            modifier = Modifier
-                .testTag(CONTACT_FIELD.ROW)
-                .fillMaxWidth()
-                .height(56.dp) // matches the built-in app bar height
-                .background(color = Purple500)
-                .clickable { // go to the profile of the other user or show the event
+        TopAppBar(
+            modifier = Modifier.testTag(CONTACT_FIELD.ROW)
+                .clickable {
                     store.removeChatListener(chatId)
 
                     // if it is a group chat, chatId is the event id
@@ -255,43 +251,30 @@ class ChatActivity : ComponentActivity() {
                         context.startActivity(coachProfileIntent)
                     }
                 },
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            // Button icon for the back button
-            IconButton(
-                onClick = {
-                    store.removeChatListener(chatId)
-                    // go back to the listed contacts (msg contacts or coaches)
-                    val intent = Intent(context, CoachesListActivity::class.java)
-                    intent.putExtra("isViewingContacts", true)
-                    context.startActivity(intent)
-
-                },
-                modifier = Modifier
-                    .testTag(BACK)
-                    .padding(start = 5.dp)
-                    .align(Alignment.CenterVertically)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.ArrowBack,
-                    contentDescription = "Back",
-                    tint = Color.White
+            title = {
+                Text(
+                    text = if (isGroupChat) groupEvent.event.name else "${toUser.firstName} ${toUser.lastName}",
+                    modifier = Modifier.testTag(CONTACT_FIELD.LABEL)
                 )
-            }
+            },
+            navigationIcon = {
+                // Button icon for the back button
+                IconButton(
+                    onClick = {
+                        store.removeChatListener(chatId)
+                        // go back to previous activity
+                        finish()
 
-            Text(
-                text = if (isGroupChat) groupEvent.event.name else toUser.firstName + " " + toUser.lastName,
-                fontSize = 20.sp,
-                modifier = Modifier
-                    .testTag(CONTACT_FIELD.LABEL)
-                    .fillMaxWidth()
-                    .align(Alignment.CenterVertically)
-                    .padding(start = 10.dp),
-                color = Color.White,
-                fontWeight = FontWeight.SemiBold
-            )
-        }
+                    },
+                    modifier = Modifier.testTag(BACK)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        )
     }
 
     /**
@@ -369,7 +352,7 @@ class ChatActivity : ComponentActivity() {
         ) {
             Column(
                 modifier = Modifier
-                    .padding(20.dp)
+                    .padding(start = 20.dp, end = 20.dp, top = 10.dp)
                     .testTag(CHAT_BOX.MESSAGES_COLUMN)
             ) {
                 // Chat Messages
@@ -388,11 +371,12 @@ class ChatActivity : ComponentActivity() {
                                 .align(Alignment.CenterHorizontally)
                                 .padding(bottom = 10.dp)
                                 .background(
-                                    color = Color(0xFFE6E7E7),
+                                    color = MaterialTheme.colors.chatTime,
                                     shape = RoundedCornerShape(10.dp)
                                 )
                                 .padding(5.dp),
                             textAlign = TextAlign.Center,
+                            color = MaterialTheme.colors.onChatTime
                         )
                     }
 
@@ -418,8 +402,8 @@ class ChatActivity : ComponentActivity() {
         nbParticipants: Int
     ) {
         val timestampFormatter = DateTimeFormatter.ofPattern("HH:mm")
-        val timeAndUnreadMarkColor = Color(0xFF6C6C6D)
-        val readMarkColor = Color(0xFF0027FF)
+        val timeAndUnreadMarkColor = MaterialTheme.colors.onMessageTimeStamp
+        val readMarkColor = MaterialTheme.colors.readMessageCheck
 
         Row(
             modifier = Modifier
@@ -446,7 +430,7 @@ class ChatActivity : ComponentActivity() {
                         .testTag(CHAT_MESSAGE.LABEL)
                         .fillMaxWidth(0.7f)
                         .background(
-                            color = if (isFromCurrentUser) Color(0xFFBBC5FD) else Color.LightGray,
+                            color = if (isFromCurrentUser) MaterialTheme.colors.messageMe else MaterialTheme.colors.messageOther,
                             shape = RoundedCornerShape(
                                 10.dp,
                                 10.dp,
@@ -455,8 +439,8 @@ class ChatActivity : ComponentActivity() {
                             )
                         )
                         .padding(start = 10.dp, end = 10.dp, top = 5.dp, bottom = 5.dp),
-
-                    )
+                    color = MaterialTheme.colors.onMessage
+                )
 
                 // timestamp for message
                 Text(
@@ -526,77 +510,76 @@ class ChatActivity : ComponentActivity() {
     ) {
         var message by remember { mutableStateOf("") }
 
-        Row(
-            modifier = Modifier
-                .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
-                .fillMaxWidth()
-                .testTag(CHAT_FIELD.ROW),
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.Start
+        Surface(
+            elevation = 4.dp,
         ) {
-            // Chat Text Field
-            TextField(
-                value = message,
-                onValueChange = { message = it },
-                placeholder = { Text("Message") },
+            Row(
                 modifier = Modifier
-                    .weight(0.8f)
-                    .testTag(CHAT_FIELD.LABEL)
-                    .background(
-                        shape = RoundedCornerShape(30.dp),
-                        color = Color.LightGray
-                    ),
-                colors = TextFieldDefaults.textFieldColors(
-                    backgroundColor = Color.Transparent,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent
-                ),
-            )
-
-            // Send Button
-            if (message.trim().isNotEmpty()) {
-                IconButton(
-                    onClick = {
-                        store.getUser(currentUserEmail).thenCompose {
-                            store.sendMessage(
-                                chat.id,
-                                Message(
-                                    currentUserEmail,
-                                    "${it.firstName} ${it.lastName}",
-                                    message.trim(),
-                                    LocalDateTime.now().toString(),
-                                    ReadState.SENT
-                                )
-                            ).thenAccept {
-                                onSend()
-                            }
-                        }
-                        message = ""
-
-                        // Place this chat at the top of the users' chat list whenever a message is sent
-                        for (participantMail in chat.participants) {
-                            store.getUser(participantMail).thenCompose {
-                                val contact =
-                                    if (isGroupChat) groupEvent.groupEventId else chat.id.replace(
-                                        participantMail,
-                                        ""
-                                    )
-                                store.updateUser(
-                                    it.copy(
-                                        chatContacts = listOf(contact) + it.chatContacts.filter { e -> e != contact })
-                                )
-                            }
-                        }
-                    },
+                    .padding(10.dp)
+                    .fillMaxWidth()
+                    .testTag(CHAT_FIELD.ROW),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Chat Text Field
+                TextField(
+                    value = message,
+                    onValueChange = { message = it },
+                    placeholder = { Text("Message") },
                     modifier = Modifier
-                        .padding(start = 8.dp)
-                        .weight(0.2f)
-                        .testTag(SEND)
-                ) {
-                    Icon(
-                        Icons.Filled.Send,
-                        contentDescription = "Send Message"
-                    )
+                        .testTag(CHAT_FIELD.LABEL)
+                        .weight(0.9f),
+                    shape = CircleShape,
+                    colors = TextFieldDefaults.textFieldColors(
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                    ),
+                )
+
+                // Send Button
+                if (message.trim().isNotEmpty()) {
+                    Spacer(modifier = Modifier.width(10.dp))
+                    IconButton(
+                        onClick = {
+                            store.getUser(currentUserEmail).thenCompose {
+                                store.sendMessage(
+                                    chat.id,
+                                    Message(
+                                        currentUserEmail,
+                                        "${it.firstName} ${it.lastName}",
+                                        message.trim(),
+                                        LocalDateTime.now().toString(),
+                                        ReadState.SENT
+                                    )
+                                ).thenAccept {
+                                    onSend()
+                                }
+                            }
+                            message = ""
+
+                            // Place this chat at the top of the users' chat list whenever a message is sent
+                            for (participantMail in chat.participants) {
+                                store.getUser(participantMail).thenCompose {
+                                    val contact =
+                                        if (isGroupChat) groupEvent.groupEventId else chat.id.replace(
+                                            participantMail,
+                                            ""
+                                        )
+                                    store.updateUser(
+                                        it.copy(
+                                            chatContacts = listOf(contact) + it.chatContacts.filter { e -> e != contact })
+                                    )
+                                }
+                            }
+                        },
+                        modifier = Modifier
+                            .testTag(SEND)
+                            .weight(0.1f)
+                    ) {
+                        Icon(
+                            Icons.Filled.Send,
+                            contentDescription = "Send Message"
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons.Default
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Tune
@@ -32,8 +33,6 @@ import com.github.sdpcoachme.location.provider.FusedLocationProvider.Companion.C
 import com.github.sdpcoachme.messaging.ChatActivity
 import com.github.sdpcoachme.profile.CoachesListActivity.TestTags.Buttons.Companion.FILTER
 import com.github.sdpcoachme.ui.*
-import com.github.sdpcoachme.ui.theme.CoachMeTheme
-import com.github.sdpcoachme.ui.theme.Purple200
 import kotlinx.coroutines.future.await
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -108,13 +107,11 @@ class CoachesListActivity : ComponentActivity() {
                 stateLoading.complete(null)
             }
 
-            val title = if (isViewingContacts) stringResource(R.string.contacts)
+            val title = if (isViewingContacts) stringResource(R.string.chats)
             else stringResource(R.string.title_activity_coaches_list)
 
-            CoachMeTheme {
-                Dashboard(title) {
-                    CoachesList(it, email, listOfCoaches, isViewingContacts, contactRowInfos)
-                }
+            Dashboard(title) {
+                CoachesList(it, email, listOfCoaches, isViewingContacts, contactRowInfos)
             }
         }
     }
@@ -168,7 +165,8 @@ class CoachesListActivity : ComponentActivity() {
                         .align(Alignment.BottomEnd)
                         .padding(16.dp)
                         .testTag(FILTER),
-                    backgroundColor = Purple200
+                    backgroundColor = MaterialTheme.colors.primary,
+                    contentColor = MaterialTheme.colors.onPrimary
                 ) {
                     Icon(
                         imageVector = Default.Tune,

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -4,47 +4,23 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Divider
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons.Default
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Tune
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.sdpcoachme.CoachMeApplication
 import com.github.sdpcoachme.R
@@ -55,11 +31,11 @@ import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.location.provider.FusedLocationProvider.Companion.CAMPUS
 import com.github.sdpcoachme.messaging.ChatActivity
 import com.github.sdpcoachme.profile.CoachesListActivity.TestTags.Buttons.Companion.FILTER
-import com.github.sdpcoachme.ui.Dashboard
+import com.github.sdpcoachme.ui.*
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.github.sdpcoachme.ui.theme.Purple200
 import kotlinx.coroutines.future.await
-import java.util.Collections
+import java.util.*
 import java.util.concurrent.CompletableFuture
 
 class CoachesListActivity : ComponentActivity() {
@@ -203,101 +179,58 @@ class CoachesListActivity : ComponentActivity() {
         }
     }
 
-    // TODO: make this composable use new ListItem composable in package ui
+    /**
+     * Displays a single user info in a list, or a chat preview if isViewingContacts is true.
+     */
     @Composable
     fun UserInfoListItem(currentUserEmail: String, user: UserInfo = UserInfo(), isViewingContacts: Boolean = false, contactRowInfo: ContactRowInfo = ContactRowInfo()) {
         val context = LocalContext.current
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable {
-                    if (isViewingContacts) {
-                        val displayChatIntent = Intent(context, ChatActivity::class.java)
-                        displayChatIntent.putExtra("chatId", contactRowInfo.chatId)
-                        context.startActivity(displayChatIntent)
-                    } else {
-                        val displayCoachIntent = Intent(context, ProfileActivity::class.java)
-                        displayCoachIntent.putExtra("email", user.email)
-                        displayCoachIntent.putExtra("isViewingCoach", true)
-                        context.startActivity(displayCoachIntent)
-                    }
-                }
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .height(100.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // TODO: might be a good idea to merge the profile picture code used here and the one used in EditProfileActivity
-            Image(
-                painter = painterResource(id = R.drawable.ic_launcher_background),
-                contentDescription = "${user.firstName} ${user.lastName}'s profile picture",
-                modifier = Modifier
-                    .size(80.dp)
-                    .clip(CircleShape)
-                    .border(2.dp, Color.Gray, CircleShape)
-            )
-            Spacer(modifier = Modifier.width(16.dp))
-            Column(
-                modifier = Modifier.fillMaxHeight(),
-                verticalArrangement = Arrangement.SpaceEvenly
-            ) {
-                Text(
-                    text = if (isViewingContacts) contactRowInfo.chatTitle else "${user.firstName} ${user.lastName}",
-                    style = MaterialTheme.typography.h6,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
 
-                if (isViewingContacts) {
+        if (isViewingContacts) {
+            ListItem(
+                image = ImageData(
+                    painter = painterResource(id = R.drawable.ic_launcher_background),
+                    contentDescription = contactRowInfo.chatTitle,
+                ),
+                title = contactRowInfo.chatTitle,
+                firstRow = {
                     val senderName = if (contactRowInfo.lastMessage.sender == currentUserEmail) "You" else contactRowInfo.lastMessage.senderName
-                    Text(
+                    IconTextRow(
                         text = if (senderName.isNotEmpty()) "$senderName: ${contactRowInfo.lastMessage.content}" else "Tap to write a message",
-                        color = Color.Gray,
-                        style = MaterialTheme.typography.body2,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                        maxLines = 2
                     )
-                } else {
-                    UserViewBody(user)
+                },
+                onClick = {
+                    val displayChatIntent = Intent(context, ChatActivity::class.java)
+                    displayChatIntent.putExtra("chatId", contactRowInfo.chatId)
+                    context.startActivity(displayChatIntent)
                 }
-
-            }
-        }
-        Divider()
-    }
-
-    @Composable
-    fun UserViewBody(user: UserInfo) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = Default.Place,
-                tint = Color.Gray,
-                contentDescription = "${user.firstName} ${user.lastName}'s location",
-                modifier = Modifier.size(20.dp)
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            // Temporary, until we implement proper location handling
-            Text(
-                text = user.address.name,
-                color = Color.Gray,
-                style = MaterialTheme.typography.body2,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+        } else {
+            ListItem(
+                image = ImageData(
+                    painter = painterResource(id = R.drawable.ic_launcher_background),
+                    contentDescription = "${user.firstName} ${user.lastName}'s profile picture",
+                ),
+                title = "${user.firstName} ${user.lastName}",
+                firstRow = {
+                    IconTextRow(
+                        icon = IconData(icon = Default.Place, contentDescription = "${user.firstName} ${user.lastName}'s location"),
+                        text = user.address.name
+                    )
+                },
+                secondRow = {
+                    IconsRow(icons = user.sports.map { sport ->
+                        IconData(icon = sport.sportIcon, contentDescription = sport.sportName)
+                    })
+                },
+                onClick = {
+                    val displayCoachIntent = Intent(context, ProfileActivity::class.java)
+                    displayCoachIntent.putExtra("email", user.email)
+                    displayCoachIntent.putExtra("isViewingCoach", true)
+                    context.startActivity(displayCoachIntent)
+                }
             )
-        }
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            user.sports.map {
-                Icon(
-                    imageVector = it.sportIcon,
-                    tint = Color.Gray,
-                    contentDescription = it.sportName,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-            }
         }
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/profile/EditTextActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/EditTextActivity.kt
@@ -169,20 +169,22 @@ class EditTextActivity : ComponentActivity() {
 
         setContent {
             CoachMeTheme {
-                EditTextLayout(
-                    onSubmit = {
-                        setResult(RESULT_OK, Intent().putExtra(RETURN_VALUE_KEY, it))
-                        finish()
-                    },
-                    onCancel = {
-                        setResult(RESULT_CANCELED)
-                        finish()
-                    },
-                    initialValue = initialValue,
-                    title = title,
-                    label = label,
-                    placeholder = placeholder
-                )
+                Surface(color = MaterialTheme.colors.background) {
+                    EditTextLayout(
+                        onSubmit = {
+                            setResult(RESULT_OK, Intent().putExtra(RETURN_VALUE_KEY, it))
+                            finish()
+                        },
+                        onCancel = {
+                            setResult(RESULT_CANCELED)
+                            finish()
+                        },
+                        initialValue = initialValue,
+                        title = title,
+                        label = label,
+                        placeholder = placeholder
+                    )
+                }
             }
         }
     }
@@ -228,12 +230,16 @@ fun EditTextLayout(
                         modifier = Modifier.testTag(DONE)
                     ) {
                         Icon(Icons.Filled.Done, "Done",
-                            tint = MaterialTheme.colors.onPrimary)
+                            tint = if (MaterialTheme.colors.isLight)
+                                MaterialTheme.colors.onPrimary
+                            else
+                                MaterialTheme.colors.onSurface
+                        )
                     }
                 })
         }
-    ) {
-        padding ->
+    ) { padding ->
+        Surface(color = MaterialTheme.colors.background) {
             Column(
                 modifier = Modifier.padding(padding)
             ) {
@@ -254,5 +260,6 @@ fun EditTextLayout(
                     )
                 )
             }
+        }
     }
 }

--- a/app/src/main/java/com/github/sdpcoachme/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/ProfileActivity.kt
@@ -43,7 +43,6 @@ import com.github.sdpcoachme.profile.ProfileActivity.TestTags.Companion.PHONE
 import com.github.sdpcoachme.profile.ProfileActivity.TestTags.Companion.PROFILE_LABEL
 import com.github.sdpcoachme.profile.ProfileActivity.TestTags.Companion.SPORTS
 import com.github.sdpcoachme.ui.Dashboard
-import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import kotlinx.coroutines.future.await
 import java.util.concurrent.CompletableFuture
 
@@ -114,15 +113,8 @@ class ProfileActivity : ComponentActivity() {
                 if (isViewingCoach) stringResource(R.string.profile_details)
                 else stringResource(R.string.my_profile)
 
-            CoachMeTheme {
-                Dashboard(title) {
-                    Surface(
-                        modifier = it.fillMaxSize(),
-                        color = MaterialTheme.colors.background
-                    ) {
-                        Profile(futureUserInfo, isViewingCoach)
-                    }
-                }
+            Dashboard(title) {
+                Profile(futureUserInfo, isViewingCoach)
             }
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/profile/SelectSportsActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/SelectSportsActivity.kt
@@ -164,18 +164,20 @@ class SelectSportsActivity : ComponentActivity() {
 
         setContent {
             CoachMeTheme {
-                SelectSportsLayout(
-                    onSubmit = {
-                        setResult(RESULT_OK, Intent().putExtra(RETURN_VALUE_KEY, it.toTypedArray()))
-                        finish()
-                    },
-                    onCancel = {
-                        setResult(RESULT_CANCELED)
-                        finish()
-                    },
-                    initialValue = initialValue,
-                    title = title
-                )
+                Surface(color = MaterialTheme.colors.background) {
+                    SelectSportsLayout(
+                        onSubmit = {
+                            setResult(RESULT_OK, Intent().putExtra(RETURN_VALUE_KEY, it.toTypedArray()))
+                            finish()
+                        },
+                        onCancel = {
+                            setResult(RESULT_CANCELED)
+                            finish()
+                        },
+                        initialValue = initialValue,
+                        title = title
+                    )
+                }
             }
         }
     }
@@ -228,24 +230,29 @@ class SelectSportsActivity : ComponentActivity() {
                             modifier = Modifier.testTag(DONE)
                         ) {
                             Icon(Icons.Filled.Done, "Done",
-                                tint = MaterialTheme.colors.onPrimary)
+                                tint = if (MaterialTheme.colors.isLight)
+                                    MaterialTheme.colors.onPrimary
+                                else
+                                    MaterialTheme.colors.onSurface
+                            )
                         }
                     })
             }
         ) { padding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(horizontal = 20.dp)
-                    .testTag(TestTags.COLUMN),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                MultiSelectList(
-                    items = sportItems,
-                    toggleSelectSport = toggleSelectSport
-                )
+            Surface(color = MaterialTheme.colors.background) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .testTag(TestTags.COLUMN),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    MultiSelectList(
+                        items = sportItems,
+                        toggleSelectSport = toggleSelectSport
+                    )
+                }
             }
         }
     }
@@ -263,6 +270,9 @@ class SelectSportsActivity : ComponentActivity() {
                 .fillMaxWidth()
                 .testTag(TestTags.MultiSelectListTag.LAZY_SELECT_COLUMN)
         ) {
+            item {
+                Divider()
+            }
             items(items.size) { i ->
                 Row (
                     modifier = Modifier
@@ -270,14 +280,24 @@ class SelectSportsActivity : ComponentActivity() {
                         .clickable {
                             toggleSelectSport(Sports.values()[i])
                         }
-                        .padding(16.dp)
+                        .padding(vertical = 20.dp, horizontal = 30.dp)
                         .testTag(TestTags.MultiSelectListTag.ROW_TEXT_LIST[i].ROW),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = items[i].element.sportName,
-                        modifier = Modifier.testTag(
-                            TestTags.MultiSelectListTag.ROW_TEXT_LIST[i].TEXT))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = items[i].element.sportIcon,
+                            contentDescription = items[i].element.sportName,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text(text = items[i].element.sportName,
+                            modifier = Modifier.testTag(
+                                TestTags.MultiSelectListTag.ROW_TEXT_LIST[i].TEXT))
+                    }
                     Icon(
                         imageVector = if (items[i].selected) Icons.Default.CheckBox else Icons.Default.CheckBoxOutlineBlank,
                         contentDescription = "Selected",
@@ -286,6 +306,7 @@ class SelectSportsActivity : ComponentActivity() {
                                     else Modifier.size(20.dp)
                     )
                 }
+                Divider()
             }
         }
     }

--- a/app/src/main/java/com/github/sdpcoachme/profile/SelectSportsActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/SelectSportsActivity.kt
@@ -10,7 +10,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -265,20 +266,19 @@ class SelectSportsActivity : ComponentActivity() {
      */
     @Composable
     fun MultiSelectList(items: List<ListItem<Sports>>, toggleSelectSport: (Sports) -> Unit) {
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag(TestTags.MultiSelectListTag.LAZY_SELECT_COLUMN)
+                .verticalScroll(rememberScrollState()),
         ) {
-            item {
-                Divider()
-            }
-            items(items.size) { i ->
+            Divider()
+            List(items.size) { i ->
                 Row (
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable {
-                            toggleSelectSport(Sports.values()[i])
+                            toggleSelectSport(items[i].element)
                         }
                         .padding(vertical = 20.dp, horizontal = 30.dp)
                         .testTag(TestTags.MultiSelectListTag.ROW_TEXT_LIST[i].ROW),
@@ -303,7 +303,7 @@ class SelectSportsActivity : ComponentActivity() {
                         contentDescription = "Selected",
                         tint = MaterialTheme.colors.primary,
                         modifier = if (items[i].selected) Modifier.size(20.dp).testTag(TestTags.MultiSelectListTag.ROW_TEXT_LIST[i].ICON)
-                                    else Modifier.size(20.dp)
+                        else Modifier.size(20.dp)
                     )
                 }
                 Divider()

--- a/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/schedule/CreateEventActivity.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalComposeUiApi::class)
 
 package com.github.sdpcoachme.schedule
 
@@ -17,9 +17,9 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -42,7 +42,6 @@ import com.github.sdpcoachme.data.schedule.EventType
 import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.location.autocomplete.AddressAutocompleteHandler
 import com.github.sdpcoachme.profile.SelectSportsActivity
-import com.github.sdpcoachme.ui.theme.CoachMeMaterial3Theme
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import com.maxkeppeker.sheets.core.models.base.Header
 import com.maxkeppeker.sheets.core.models.base.SheetState
@@ -291,7 +290,8 @@ class CreateEventActivity : ComponentActivity() {
                     .fillMaxSize()
                     .padding(padding)
             ) {
-                CoachMeMaterial3Theme {
+                // TODO: uncomment this to enable dark mode for maxkeppeler sheets
+                // CoachMeMaterial3Theme {
                     Column (
                         modifier = Modifier.padding(horizontal = 10.dp)
                     ) {
@@ -369,8 +369,8 @@ class CreateEventActivity : ComponentActivity() {
                             onDescriptionChange = { description = it }
                         )
                     }
-                }
-                }
+                // }
+            }
         }
     }
 

--- a/app/src/main/java/com/github/sdpcoachme/ui/Dashboard.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ui/Dashboard.kt
@@ -28,18 +28,12 @@ import com.github.sdpcoachme.location.MapActivity
 import com.github.sdpcoachme.profile.CoachesListActivity
 import com.github.sdpcoachme.profile.ProfileActivity
 import com.github.sdpcoachme.schedule.ScheduleActivity
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.COACHES_LIST
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.GROUP_EVENTS_LIST
 import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.HAMBURGER_MENU
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.LOGOUT
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.MESSAGING
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.PLAN
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.PROFILE
-import com.github.sdpcoachme.ui.Dashboard.TestTags.Buttons.Companion.SCHEDULE
 import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.BAR_TITLE
 import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.DASHBOARD_EMAIL
 import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.DRAWER_HEADER
 import com.github.sdpcoachme.ui.Dashboard.TestTags.Companion.MENU_LIST
+import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import java.util.concurrent.CompletableFuture
@@ -73,13 +67,16 @@ class Dashboard {
 /**
  * Dashboard UI implemented as a left-sided drawer to navigate to other application activities.
  * @param appContent = set here the root composable of the current launched activity
- * @param title = title to display on the top application bar
+ * @param title = title to display on the top application bar. It is a composable function that
+ * takes a Modifier as parameter, and the modifier must be applied to the Text composable that
+ * displays the title. This allows to add a test tag to the title, while still making it possible for
+ * the caller to pass a custom composable as title.
+ * @param UIDisplayed = future that will be completed when the UI is displayed
  */
 @Composable
-fun Dashboard(title: String? = null,
-              UIDisplayed: CompletableFuture<Void> = CompletableFuture<Void>(),
-              noElevation: Boolean = false,
-              appContent: @Composable (Modifier) -> Unit) {
+fun Dashboard(title: @Composable (Modifier) -> Unit,
+                UIDisplayed: CompletableFuture<Void> = CompletableFuture<Void>(),
+                appContent: @Composable (Modifier) -> Unit) {
 
     val context = LocalContext.current
     // equivalent to remember { ScaffoldState(...) }
@@ -88,91 +85,175 @@ fun Dashboard(title: String? = null,
     // enables us to launch a coroutine tied to a specific lifecycle
     val coroutineScope = rememberCoroutineScope()
 
-    Scaffold(
-        scaffoldState = scaffoldState,
-        topBar = {
-            AppBar(
-                title = title ?: stringResource(id = R.string.app_name),
-                onNavigationIconClick = { coroutineScope.launch {scaffoldState.drawerState.open()} },
-                noElevation = noElevation
-            )},
-        drawerGesturesEnabled = scaffoldState.drawerState.isOpen,
-        drawerContent = {
-            DrawerHeader(context, UIDisplayed)
-            DrawerBody(
-                items = listOf(
-                    MenuItem(tag = PLAN, title = "Map",
-                        contentDescription = "Return to main map",
-                        icon = Default.Map),
-                    MenuItem(tag = COACHES_LIST, title = "Nearby coaches",
-                        contentDescription = "See a list of coaches available close to you",
-                        icon = Default.People),
-                    MenuItem(tag = GROUP_EVENTS_LIST, title = "Group events",
-                        contentDescription = "See a list of events organized by coaches close to you",
-                        icon = Default.Groups),
-                    MenuItem(tag = SCHEDULE, title = "Schedule",
-                        contentDescription = "See schedule",
-                        icon = Default.Today),
-                    MenuItem(tag = MESSAGING, title = "Messaging",
-                        contentDescription = "Go to Messaging section",
-                        icon = Default.Chat),
-                    MenuItem(tag = PROFILE, title = "My profile",
-                        contentDescription = "Go to profile",
-                        icon = Default.ManageAccounts),
-                    MenuItem(tag = LOGOUT, title = "Log out",
-                            contentDescription = "User logs out",
-                            icon = Default.Logout)
-                ),
-                onItemClick = {
-                    when (it.tag) {
-                        PLAN -> {
-                            context.startActivity(Intent(context, MapActivity::class.java))
-                        }
-                        PROFILE -> {
-                            context.startActivity(Intent(context, ProfileActivity::class.java))
-                        }
-                        LOGOUT -> {
-                            (context.applicationContext as CoachMeApplication).authenticator.signOut(context) {
-                                (context.applicationContext as CoachMeApplication).store.setCurrentEmail("")
-                                    .thenApply {
-                                        context.startActivity(Intent(context, LoginActivity::class.java))
+    CoachMeTheme {
+        Surface(
+            color = MaterialTheme.colors.background,
+        ) {
+            Scaffold(
+                scaffoldState = scaffoldState,
+                topBar = {
+                    AppBar(
+                        title = title,
+                        onNavigationIconClick = { coroutineScope.launch { scaffoldState.drawerState.open() } }
+                    )
+                },
+                drawerGesturesEnabled = scaffoldState.drawerState.isOpen,
+                drawerContent = {
+                    Surface(
+                        color = MaterialTheme.colors.background
+                    ) {
+                        Column {
+                            DrawerHeader(context, UIDisplayed)
+                            DrawerBody(
+                                items = listOf(
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.PLAN, title = "Map",
+                                        contentDescription = "Return to main map",
+                                        icon = Default.Map
+                                    ),
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.COACHES_LIST, title = "Nearby coaches",
+                                        contentDescription = "See a list of coaches available close to you",
+                                        icon = Default.People
+                                    ),
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.GROUP_EVENTS_LIST, title = "Group events",
+                                        contentDescription = "See a list of events organized by coaches close to you",
+                                        icon = Default.Groups
+                                    ),
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.SCHEDULE, title = "Schedule",
+                                        contentDescription = "See schedule",
+                                        icon = Default.Today
+                                    ),
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.MESSAGING, title = "Chats",
+                                        contentDescription = "Go to Messaging section",
+                                        icon = Default.Chat
+                                    ),
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.PROFILE, title = "My profile",
+                                        contentDescription = "Go to profile",
+                                        icon = Default.ManageAccounts
+                                    ),
+                                    MenuItem(
+                                        tag = Dashboard.TestTags.Buttons.LOGOUT, title = "Log out",
+                                        contentDescription = "User logs out",
+                                        icon = Default.Logout
+                                    )
+                                ),
+                                onItemClick = {
+                                    when (it.tag) {
+                                        Dashboard.TestTags.Buttons.PLAN -> {
+                                            context.startActivity(
+                                                Intent(
+                                                    context,
+                                                    MapActivity::class.java
+                                                )
+                                            )
+                                        }
+                                        Dashboard.TestTags.Buttons.PROFILE -> {
+                                            context.startActivity(
+                                                Intent(
+                                                    context,
+                                                    ProfileActivity::class.java
+                                                )
+                                            )
+                                        }
+                                        Dashboard.TestTags.Buttons.LOGOUT -> {
+                                            (context.applicationContext as CoachMeApplication).authenticator.signOut(
+                                                context
+                                            ) {
+                                                (context.applicationContext as CoachMeApplication).store.setCurrentEmail(
+                                                    ""
+                                                )
+                                                    .thenApply {
+                                                        context.startActivity(
+                                                            Intent(
+                                                                context,
+                                                                LoginActivity::class.java
+                                                            )
+                                                        )
+                                                    }
+                                            }
+                                        }
+                                        Dashboard.TestTags.Buttons.SCHEDULE -> {
+                                            context.startActivity(
+                                                Intent(
+                                                    context,
+                                                    ScheduleActivity::class.java
+                                                )
+                                            )
+                                        }
+                                        Dashboard.TestTags.Buttons.COACHES_LIST -> {
+                                            context.startActivity(
+                                                Intent(
+                                                    context,
+                                                    CoachesListActivity::class.java
+                                                )
+                                            )
+                                        }
+                                        Dashboard.TestTags.Buttons.MESSAGING -> {
+                                            val intent =
+                                                Intent(context, CoachesListActivity::class.java)
+                                            intent.putExtra("isViewingContacts", true)
+                                            context.startActivity(intent)
+                                        }
+                                        Dashboard.TestTags.Buttons.GROUP_EVENTS_LIST -> {
+                                            context.startActivity(
+                                                Intent(
+                                                    context,
+                                                    GroupEventsListActivity::class.java
+                                                )
+                                            )
+                                        }
+                                        else -> {
+                                            throw IllegalStateException("Unknown tab clicked: ${it.tag}")
+                                        }
                                     }
-                            }
+                                }
+                            )
                         }
-                        SCHEDULE -> {
-                            context.startActivity(Intent(context, ScheduleActivity::class.java))
-                        }
-                        COACHES_LIST -> {
-                            context.startActivity(Intent(context, CoachesListActivity::class.java))
-                        }
-                        MESSAGING -> {
-                            val intent = Intent(context, CoachesListActivity::class.java)
-                            intent.putExtra("isViewingContacts", true)
-                            context.startActivity(intent)
-                        }
-                        GROUP_EVENTS_LIST -> {
-                            context.startActivity(Intent(context, GroupEventsListActivity::class.java))
-                        }
-                        else -> {
-                            throw IllegalStateException("Unknown tab clicked: ${it.tag}")
-                        }
+                    }
+                },
+                content = { innerPadding ->
+                    Surface(
+                        color = MaterialTheme.colors.background
+                    ) {
+                        // invokes dashboardContent composable with correct padding
+                        appContent(Modifier.padding(innerPadding))
                     }
                 }
             )
-        },
-        content = { innerPadding ->
-            // invokes dashboardContent composable with correct padding
-            appContent(Modifier.padding(innerPadding))
         }
+    }
+}
+
+/**
+ * Overloaded version of [Dashboard] that takes a String as title, and displays it as a [Text] composable
+ * in the top application bar.
+ *
+ * @param title = title to display on the top application bar
+ * @param appContent = set here the root composable of the current launched activity
+ * @param UIDisplayed = future that will be completed when the UI is displayed
+ */
+@Composable
+fun Dashboard(title: String? = null,
+              UIDisplayed: CompletableFuture<Void> = CompletableFuture<Void>(),
+              appContent: @Composable (Modifier) -> Unit) {
+    Dashboard(
+        title = { modifier -> Text(text = title ?: stringResource(id = R.string.app_name), modifier = modifier) },
+        UIDisplayed = UIDisplayed,
+        appContent = appContent
     )
 }
 
 @Composable
-fun AppBar(title: String, onNavigationIconClick: () -> Unit, noElevation: Boolean = false) {
+fun AppBar(title: @Composable (Modifier) -> Unit, onNavigationIconClick: () -> Unit, noElevation: Boolean = false) {
     TopAppBar(
-        title = { Text(text = title, modifier = Modifier.testTag(BAR_TITLE)) },
-        backgroundColor = MaterialTheme.colors.primary,
-        contentColor = MaterialTheme.colors.onPrimary,
+        title = {
+            title(Modifier.testTag(BAR_TITLE))
+        },
         navigationIcon = {
             IconButton(
                 modifier = Modifier.testTag(HAMBURGER_MENU),

--- a/app/src/main/java/com/github/sdpcoachme/ui/ListItem.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ui/ListItem.kt
@@ -21,6 +21,18 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
+/**
+ * A generic list item that can be used in a vertical list.
+ *
+ * @param image the image to display on the left side of the list item
+ * @param title the title to display on the list item
+ * @param titleTag the tag to use for the title
+ * @param firstRow the first row to display below the title
+ * @param secondRow the second row to display below the first row
+ * @param secondColumn the column to display on the right side of the list item
+ * @param firstColumnMaxWidth the max width of the first column (includes title, first row, and second row)
+ * @param onClick the action to perform when the list item is clicked
+ */
 @Composable
 fun ListItem(
     image: ImageData? = null,
@@ -93,34 +105,98 @@ fun ListItem(
     Divider()
 }
 
+/**
+ * A generic small list item that can be used in a vertical list.
+ *
+ * @param image the image to display on the left side of the list item
+ * @param title the title to display on the list item
+ * @param titleTag the tag to use for the title
+ * @param onClick the action to perform when the list item is clicked
+ */
+@Composable
+fun SmallListItem(
+    image: ImageData? = null,
+    title: String,
+    titleTag: String? = null,
+    onClick: (() -> Unit)? = null
+) {
+    Row(
+        modifier =
+        if (onClick != null) {
+            Modifier.clickable(onClick = onClick)
+        } else {
+            Modifier
+        }
+            .padding(10.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        image?.let {
+            Image(
+                painter = image.painter,
+                contentDescription = image.contentDescription,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .border(2.dp, Color.Gray, CircleShape)
+                    .padding(0.dp, 0.dp, 0.dp, 0.dp)
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+        }
+        Text(
+            modifier = titleTag?.let { Modifier.testTag(titleTag) } ?: Modifier,
+            text = title,
+            style = MaterialTheme.typography.body1
+        )
+    }
+    Divider()
+}
+
+/**
+ * This composable can be used as a row in a list item, containing an icon and text. The icon is
+ * optional.
+ *
+ * @param icon the icon displayed on the left side of the row
+ * @param text the text displayed next to the icon
+ * @param maxLines the max number of lines to display for the text
+ * @param textTag the tag to use for the text
+ */
 @Composable
 fun IconTextRow(
-    icon: IconData,
+    icon: IconData? = null,
     text: String,
+    maxLines: Int = 1,
     textTag: String? = null
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            imageVector = icon.icon,
-            tint = Color.Gray,
-            contentDescription = icon.contentDescription,
-            modifier = Modifier.size(20.dp)
-        )
-        Spacer(modifier = Modifier.width(4.dp))
+        icon?.let {
+            Icon(
+                imageVector = icon.icon,
+                tint = Color.Gray,
+                contentDescription = icon.contentDescription,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+        }
         // Temporary, until we implement proper location handling
         Text(
             modifier = textTag?.let { Modifier.testTag(textTag) } ?: Modifier,
             text = text,
             color = Color.Gray,
             style = MaterialTheme.typography.body2,
-            maxLines = 1,
+            maxLines = maxLines,
             overflow = TextOverflow.Ellipsis
         )
     }
 }
 
+/**
+ * This composable can be used as a row in a list item, containing a list of icons.
+ *
+ * @param icons the list of icons to display
+ */
 @Composable
 fun IconsRow(
     icons: List<IconData>
@@ -140,6 +216,16 @@ fun IconsRow(
     }
 }
 
+/**
+ * This composable is used to display a label in a list item. The label contains text and an optional
+ * icon.
+ *
+ * @param text the text to display in the label
+ * @param textTag the tag to use for the text
+ * @param icon the icon to display in the label
+ * @param backgroundColor the background color of the label
+ * @param contentColor the color of the text and icon in the label
+ */
 @Composable
 fun Label(
     text: String,
@@ -174,11 +260,17 @@ fun Label(
     }
 }
 
+/**
+ * Represents an icon and its content description. Used to more easily pass icons as parameters.
+ */
 data class IconData(
     val icon: ImageVector,
     val contentDescription: String
 )
 
+/**
+ * Represents an image and its content description. Used to more easily pass images as parameters.
+ */
 data class ImageData(
     val painter: Painter,
     val contentDescription: String

--- a/app/src/main/java/com/github/sdpcoachme/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ui/theme/Color.kt
@@ -2,8 +2,16 @@ package com.github.sdpcoachme.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+val Purple50 = Color(0xFFF2E7FE)
+val Purple100 = Color(0xFFDBB2FF)
 val Purple200 = Color(0xFFBB86FC)
 val Purple500 = Color(0xFF6200EE)
 val Purple700 = Color(0xFF3700B3)
+val Purple800 = Color(0xFF30009C)
+val Purple900 = Color(0xFF23036A)
 val Teal200 = Color(0xFF03DAC5)
 val DarkOrange = Color(0xFFFF8C00)
+val LightPrettyBlue = Color(0xFF64B5F6)
+val DarkPrettyBlue = Color(0xFF1976D2)
+val DarkDarkGray = Color(0xFF212121)
+val LightLightGray = Color(0xFFEEEEEE)

--- a/app/src/main/java/com/github/sdpcoachme/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ui/theme/Theme.kt
@@ -1,10 +1,14 @@
 package com.github.sdpcoachme.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColors(
     primary = Purple200,
@@ -27,6 +31,39 @@ private val LightColorPalette = lightColors(
     */
 )
 
+// Adding extra colors for messages and other things
+
+// Label for group event items
+@get:Composable
+val Colors.label: Color
+    get() = DarkOrange
+@get:Composable
+val Colors.onLabel: Color
+    get() = Color.White
+
+// Label for chat
+@get:Composable
+val Colors.messageMe: Color
+    get() = if (isLight) Purple100 else Purple800 // or Purple900 ?
+@get:Composable
+val Colors.messageOther: Color
+    get() = if (isLight) Color.LightGray else DarkDarkGray
+@get:Composable
+val Colors.onMessage: Color
+    get() = if (isLight) Color.Black else Color.White
+@get:Composable
+val Colors.onMessageTimeStamp: Color
+    get() = if (isLight) Color.DarkGray else Color.LightGray
+@get:Composable
+val Colors.chatTime: Color
+    get() = if (isLight) LightLightGray else Color.DarkGray
+@get:Composable
+val Colors.onChatTime: Color
+    get() = if (isLight) Color.Black else Color.White
+@get:Composable
+val Colors.readMessageCheck: Color
+    get() = if (isLight) DarkPrettyBlue else LightPrettyBlue
+
 @Composable
 fun CoachMeTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     val colors = if (darkTheme) {
@@ -39,6 +76,45 @@ fun CoachMeTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composabl
         colors = colors,
         typography = Typography,
         shapes = Shapes,
+        content = content
+    )
+}
+
+
+// Create material 3 theme to make sure the sheets from maxkeppeler pick up the dark mode
+val AppDarkMaterial3ColorScheme = darkColorScheme(
+    primary = DarkColorPalette.primary,
+    secondary = DarkColorPalette.primary,
+    tertiary = DarkColorPalette.primaryVariant
+)
+val AppLightMaterial3ColorScheme = lightColorScheme(
+    primary = LightColorPalette.primary,
+    secondary = LightColorPalette.primary,
+    tertiary = LightColorPalette.primaryVariant
+)
+
+val Material3Typography = androidx.compose.material3.Typography(
+    bodyLarge = Typography.body1
+)
+
+val Material3Shapes = androidx.compose.material3.Shapes(
+    small = Shapes.small,
+    medium = Shapes.medium,
+    large = Shapes.large
+)
+
+@Composable
+fun CoachMeMaterial3Theme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+    val appColorScheme = if (darkTheme) {
+        AppDarkMaterial3ColorScheme
+    } else {
+        AppLightMaterial3ColorScheme
+    }
+
+    androidx.compose.material3.MaterialTheme(
+        colorScheme = appColorScheme,
+        typography = Material3Typography,
+        shapes = Material3Shapes,
         content = content
     )
 }

--- a/app/src/main/java/com/github/sdpcoachme/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ui/theme/Theme.kt
@@ -5,8 +5,6 @@ import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
@@ -82,25 +80,26 @@ fun CoachMeTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composabl
 
 
 // Create material 3 theme to make sure the sheets from maxkeppeler pick up the dark mode
-val AppDarkMaterial3ColorScheme = darkColorScheme()
-val AppLightMaterial3ColorScheme = lightColorScheme()
-
-val Material3Typography = androidx.compose.material3.Typography()
-
-val Material3Shapes = androidx.compose.material3.Shapes()
-
-@Composable
-fun CoachMeMaterial3Theme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
-    val appColorScheme = if (darkTheme) {
-        AppDarkMaterial3ColorScheme
-    } else {
-        AppLightMaterial3ColorScheme
-    }
-
-    androidx.compose.material3.MaterialTheme(
-        colorScheme = appColorScheme,
-        typography = Material3Typography,
-        shapes = Material3Shapes,
-        content = content
-    )
-}
+// TODO: uncomment this to enable dark mode for maxkeppeler sheets
+//val AppDarkMaterial3ColorScheme = darkColorScheme()
+//val AppLightMaterial3ColorScheme = lightColorScheme()
+//
+//val Material3Typography = androidx.compose.material3.Typography()
+//
+//val Material3Shapes = androidx.compose.material3.Shapes()
+//
+//@Composable
+//fun CoachMeMaterial3Theme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+//    val appColorScheme = if (darkTheme) {
+//        AppDarkMaterial3ColorScheme
+//    } else {
+//        AppLightMaterial3ColorScheme
+//    }
+//
+//    androidx.compose.material3.MaterialTheme(
+//        colorScheme = appColorScheme,
+//        typography = Material3Typography,
+//        shapes = Material3Shapes,
+//        content = content
+//    )
+//}

--- a/app/src/main/java/com/github/sdpcoachme/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/sdpcoachme/ui/theme/Theme.kt
@@ -82,26 +82,12 @@ fun CoachMeTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composabl
 
 
 // Create material 3 theme to make sure the sheets from maxkeppeler pick up the dark mode
-val AppDarkMaterial3ColorScheme = darkColorScheme(
-    primary = DarkColorPalette.primary,
-    secondary = DarkColorPalette.primary,
-    tertiary = DarkColorPalette.primaryVariant
-)
-val AppLightMaterial3ColorScheme = lightColorScheme(
-    primary = LightColorPalette.primary,
-    secondary = LightColorPalette.primary,
-    tertiary = LightColorPalette.primaryVariant
-)
+val AppDarkMaterial3ColorScheme = darkColorScheme()
+val AppLightMaterial3ColorScheme = lightColorScheme()
 
-val Material3Typography = androidx.compose.material3.Typography(
-    bodyLarge = Typography.body1
-)
+val Material3Typography = androidx.compose.material3.Typography()
 
-val Material3Shapes = androidx.compose.material3.Shapes(
-    small = Shapes.small,
-    medium = Shapes.medium,
-    large = Shapes.large
-)
+val Material3Shapes = androidx.compose.material3.Shapes()
 
 @Composable
 fun CoachMeMaterial3Theme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {

--- a/app/src/main/java/com/github/sdpcoachme/weather/WeatherView.kt
+++ b/app/src/main/java/com/github/sdpcoachme/weather/WeatherView.kt
@@ -1,9 +1,9 @@
 package com.github.sdpcoachme.weather
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -61,7 +61,7 @@ private fun WeatherColumn(weatherText: String, weatherCode: Int) {
         modifier = Modifier.fillMaxWidth().testTag("WEATHER_COLUMN"),
         horizontalAlignment = CenterHorizontally
     ) {
-        Image(
+        Icon(
             painter = painterResource(id = weatherCode),
             contentDescription = "Weather icon",
             modifier = Modifier.size(35.dp).testTag(weatherCode.toString())

--- a/app/src/main/res/raw/google_maps_dark_theme.json
+++ b/app/src/main/res/raw/google_maps_dark_theme.json
@@ -1,0 +1,161 @@
+[
+  {
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#242f3e"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#746855"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#242f3e"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.locality",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#263c3f"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#6b9a76"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#38414e"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#212a37"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9ca5b3"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#746855"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#1f2835"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#f3d19c"
+      }
+    ]
+  },
+  {
+    "featureType": "transit",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#2f3948"
+      }
+    ]
+  },
+  {
+    "featureType": "transit.station",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#17263c"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#515c6d"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#17263c"
+      }
+    ]
+  }
+]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="title_activity_group_event_details">Event details</string>
     <string name="title_activity_group_events_list">Group events</string>
 
-    <string name="contacts">Contacts</string>
+    <string name="chats">Chats</string>
     <string name="my_profile">My profile</string>
     <string name="profile_details">Profile details</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <style name="Theme.CoachMe" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">@color/purple_700</item>
-    </style>
+    <style name="Theme.CoachMe" parent="Theme.MaterialComponents.DayNight" />
 </resources>


### PR DESCRIPTION
This PR mainly consists in adapting all the activities to enable make sure they react correctly to a switch to dark mode in the android system settings. A few things to note:
* Some activities were found to be using a custom TopAppBar "homemade". Those were all converted to using Jetpack Compose' built-in TopAppBar for consistency. This also allows the bar to support dark mode natively. Those activities usually had unexpected behavior when clicking on the back button of the bar (launching an intent to a specific activity instead of just closing the current activity). Those behaviors have been fixed for consistency. Now, clicking on a back button throughout the app always means the same thing: closing the current activity and going back to the previous one.
* The schedule activity now uses the dashboard as a TopAppBar with a custom title, making it more consistent with other main activities of the app. After some testing, I found that keeping the color of the text black for schedule events made the text the most visible. I tried dynamically choosing the color of the text based on the color of the event in the schedule, but having some events with white text and some with black text didn't seem nice to me. The code is still here, commented out if we decide to use it.
* The TopAppBar is now black in dark mode, as opposed to purple, as it is preferred to avoid having large surfaces filled with bright colors in dark mode. This is also the default behavior of the built-in jetpack Compose' TopAppBar.
* The chat activity colors had to be adapted for dark mode. Don't hesitate to give feedback if you don't like them.
* The map colors were also updated to a night theme when in dark mode.
* For the CreateEventActivity, the only issue was about the Dialogs using the maxkeppeler library. Those are using Material 3, which uses a different theme system. I tried enabling material 3 in our app and providing a theme to those components, and everything runs well locally, but some dependency of material 3 seems to need JDK version 9 or above to be compiled, and the CI currently runs JDK 8. A question was posted on Discord for a solution, but for now, the changes regarding material 3 theming were reverted, so that all changes can be merged to main quickly. If necessary, a second PR will be done to fix this, but for now, the maxkeppeler dialogs are displayed in white no matter the theme :(
* The Google Places Autocomplete activity also only partially supports dark mode, and there is nothing that can be done about it.

Other minor changes:
* A good amount of new sports were added to the Sports enum. The SelectSportsList activity was also adapted to better handle a big list of sports. Test also had to be adapted to support scrolling through the sports list that might not always be displayed entirely. A few issues had to be addressed, mainly the fact that the use of LazyColumn in the SelectSportsList activity didn't allow tests to detect compose elements not currently displayed by the list, so it was swapped with a regular Column.
* A loading animation was added to the login activity to make sure the user knows the map activity is being launched.
* Some composables were modularized to used the same design (list item components) in ListItem.kt. This was part of my last PR, but could not be finished properly.
* As per comments in the last PR, documentation was added to those composables and activities related to group events.

Note that the CreateEventActivity looks a bit off compared to the design of the rest of the app. It might need some rework, which was not done here.