### PR TITLE
Change the way of redirection of own's coach profile

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/location/MapActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/location/MapActivityTest.kt
@@ -43,9 +43,6 @@ import java.util.concurrent.TimeUnit.SECONDS
  */
 @RunWith(AndroidJUnit4::class)
 class MapActivityTest {
-
-    // TODO add tests for markers
-
     private val random = LatLng(42.0,42.0)
 
     @get: Rule
@@ -91,6 +88,7 @@ class MapActivityTest {
         composeTestRule.setContent {
             CoachMeTheme() {
                 Map(
+                    email = "",
                     modifier = Modifier.fillMaxWidth(),
                     lastUserLocation = lastUserLocation
                 )
@@ -111,7 +109,7 @@ class MapActivityTest {
         val lastUserLocation: MutableState<LatLng?> = mutableStateOf(firstLocation)
         composeTestRule.setContent {
             CoachMeTheme() {
-                Map(modifier = Modifier.fillMaxWidth(),lastUserLocation = lastUserLocation)
+                Map(email = "", modifier = Modifier.fillMaxWidth(),lastUserLocation = lastUserLocation)
             }
         }
         composeTestRule.onNodeWithTag(firstTag).assertExists()

--- a/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/profile/CoachesListActivityTest.kt
@@ -132,6 +132,25 @@ open class CoachesListActivityTest {
     }
 
     @Test
+    fun whenClickingOnOwnCoachProfileActivityShowsOwnProfile() {
+        val coach = COACH_1
+        store.setCurrentEmail(coach.email).thenApply {
+            // Click on own element
+            composeTestRule.onNodeWithText(coach.address.name).assertIsDisplayed()
+            composeTestRule.onNodeWithText("${coach.firstName} ${coach.lastName}")
+                .assertIsDisplayed()
+                .performClick()
+
+            // Check that the ProfileActivity is launched with the correct extras
+            Intents.intended(allOf(
+                hasComponent(ProfileActivity::class.java.name),
+                hasExtra("email", coach.email),
+                hasExtra("isViewingCoach", false)
+            ))
+        }
+    }
+
+    @Test
     fun dashboardHasRightTitleOnNearbyCoachesList() {
         val title = (InstrumentationRegistry.getInstrumentation()
             .targetContext.applicationContext as CoachMeApplication).getString(R.string.title_activity_coaches_list)

--- a/app/src/main/java/com/github/sdpcoachme/location/MapActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/location/MapActivity.kt
@@ -89,18 +89,20 @@ class MapActivity : ComponentActivity() {
         // all.
         // Note: this is absolutely not scalable, but we can change this later on.
         val futureUsers = store.getAllUsers().thenApply { users -> users.filter { it.coach } }
-        setContent {
-            Dashboard {
-                Map(
-                    modifier = it,
-                    lastUserLocation = locationProvider.getLastLocation(),
-                    futureCoachesToDisplay = futureUsers,
-                    markerLoading = markerLoading,
-                    mapLoading = mapLoading)
+        store.getCurrentEmail().thenApply { email ->
+            setContent {
+                Dashboard {
+                    Map(
+                        email = email,
+                        modifier = it,
+                        lastUserLocation = locationProvider.getLastLocation(),
+                        futureCoachesToDisplay = futureUsers,
+                        markerLoading = markerLoading,
+                        mapLoading = mapLoading)
+                }
             }
         }
     }
-
 }
 
 /**
@@ -110,6 +112,7 @@ class MapActivity : ComponentActivity() {
  */
 @Composable
 fun Map(
+    email: String,
     modifier: Modifier,
     lastUserLocation: MutableState<LatLng?>,
     // Those 2 arguments have default values to avoid refactoring older tests
@@ -169,10 +172,14 @@ fun Map(
                 tag = MARKER(user),
                 onInfoWindowClick = {
                     // TODO: code similar to CoachesList, might be able to modularize
-                    // Launches the ProfileActivity to display the coach's profile
                     val displayCoachIntent = Intent(context, ProfileActivity::class.java)
                     displayCoachIntent.putExtra("email", user.email)
-                    displayCoachIntent.putExtra("isViewingCoach", true)
+                    if (user.email == email) {
+                        displayCoachIntent.putExtra("isViewingCoach", false)
+                    } else {
+                        displayCoachIntent.putExtra("isViewingCoach", true)
+                    }
+                    // Launches the ProfileActivity to display the coach's profile
                     context.startActivity(displayCoachIntent)
                 }
             ) {

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -225,7 +225,11 @@ class CoachesListActivity : ComponentActivity() {
                 onClick = {
                     val displayCoachIntent = Intent(context, ProfileActivity::class.java)
                     displayCoachIntent.putExtra("email", user.email)
-                    displayCoachIntent.putExtra("isViewingCoach", true)
+                    if (user.email == currentUserEmail) {
+                        displayCoachIntent.putExtra("isViewingCoach", false)
+                    } else {
+                        displayCoachIntent.putExtra("isViewingCoach", true)
+                    }
                     context.startActivity(displayCoachIntent)
                 }
             )


### PR DESCRIPTION
# Mini PR
This PR changes the behaviour of clicking on elements that represent one's own coach profile. 
In the case where coaches are in the CoachesListActivity, they can still click on the list element that represents themselves. But now, they get redirected to their own profile which is the same view as if the coach pressed on "My Profile" in the dashboard. So, the coach will be able to see the modifiable view of his own profile instead of just the read-only view. 

The same adaption was made for the case where coaches are in the Map view and click on the infoWindow of their own location.

The diff coverage might not be that good because the code concerning the map cannot be tested because of the known problem of not being able to test markers. 