### PR TITLE
Push notification bugfix

### DIFF
--- a/app/src/androidTest/java/com/github/sdpcoachme/messaging/ChatActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/messaging/ChatActivityTest.kt
@@ -441,6 +441,23 @@ class ChatActivityTest {
         }
     }
 
+    // simulates push notifications where the user logs out after receiving the notification and then logs in
+    @Test
+    fun chatActivityRecoversFromMissingCurrentUserEmailIfItIsPassedInTheIntentExtra() {
+        store.setCurrentEmail("").get(1000, TimeUnit.MILLISECONDS)
+        val emailRecoveryIntent = personalChatDefaultIntent
+            .putExtra("pushNotification_currentUserEmail", currentUser.email)
+
+        ActivityScenario.launch<ChatActivity>(emailRecoveryIntent).use {
+            waitForLoading(it)
+
+            composeTestRule.onNodeWithTag(BACK).assertIsDisplayed()
+            composeTestRule.onNodeWithTag(CONTACT_FIELD.LABEL, useUnmergedTree = true).assertTextEquals(toUser.firstName + " " + toUser.lastName)
+            composeTestRule.onNodeWithTag(CHAT_FIELD.LABEL, useUnmergedTree = true).assertIsDisplayed()
+            composeTestRule.onNodeWithTag(CHAT_BOX.CONTAINER).assertIsDisplayed()
+        }
+    }
+
 
     // Waits for the activity to finish loading any async state
     private fun waitForLoading(scenario: ActivityScenario<ChatActivity>) {

--- a/app/src/androidTest/java/com/github/sdpcoachme/messaging/InAppNotifierTest.kt
+++ b/app/src/androidTest/java/com/github/sdpcoachme/messaging/InAppNotifierTest.kt
@@ -148,6 +148,11 @@ class InAppNotifierTest {
         }
     }
 
+    // This test checks that the emails of the users can be recovered when receiving a push notification while the app is
+    // open, then logging out and closing the application. After closing the application, the notification is pressed.
+    // This was a bugfix as, before, the app would crash since the email of the user was no longer stored in the app.
+    // Thanks to this test, we can ensure that the email still can be recovered even after having logged out so that
+    // clicking on the notification does not result in an error.
     @Test
     fun onMessageReceivedEnablesEmailRecoveryAndOpensChatActivityWhenUserReceivesNotificationThenLoggsOutAndThenClicksOnIt() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), MapActivity::class.java)
@@ -183,6 +188,8 @@ class InAppNotifierTest {
         }
     }
 
+    // This test checks the same email recovery as the previous test, however, this time the notification
+    // does not contain the chat id which means that the expected activity to be opened is the contacts listing.
     @Test
     fun onMessageReceivedEnablesEmailRecoveryAndOpensContactsListWhenUserReceivesNotificationWithoutChatIdThenLoggsOutAndThenClicksOnIt() {
         val context = ApplicationProvider.getApplicationContext() as CoachMeApplication

--- a/app/src/main/java/com/github/sdpcoachme/auth/LoginActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/auth/LoginActivity.kt
@@ -29,8 +29,8 @@ import com.github.sdpcoachme.auth.LoginActivity.TestTags.Buttons.Companion.LOG_I
 import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.errorhandling.ErrorHandlerLauncher
 import com.github.sdpcoachme.location.MapActivity
-import com.github.sdpcoachme.messaging.ChatActivity
 import com.github.sdpcoachme.messaging.InAppNotificationService
+import com.github.sdpcoachme.profile.CoachesListActivity
 import com.github.sdpcoachme.ui.theme.CoachMeTheme
 import kotlinx.coroutines.future.await
 import java.util.concurrent.CompletableFuture
@@ -197,8 +197,10 @@ class LoginActivity : ComponentActivity() {
                 if (action.equals("OPEN_CHAT_ACTIVITY")
                     && pushNotificationIntent.getStringExtra("chatId") != null) {
                     // If a notification was clicked, redirect to chat activity
-                    Intent(this, ChatActivity::class.java)
+                    Intent(this, CoachesListActivity::class.java)
+                        .putExtra("openChat", true)
                         .putExtra("chatId", pushNotificationIntent.getStringExtra("chatId"))
+                        .putExtra("pushNotification_currentUserEmail", email)
                 } else {
                     // If no notification was clicked, redirect to map activity
                     Intent(this, MapActivity::class.java)

--- a/app/src/main/java/com/github/sdpcoachme/messaging/ChatActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/messaging/ChatActivity.kt
@@ -109,6 +109,13 @@ class ChatActivity : ComponentActivity() {
 
         store = (application as CoachMeApplication).store
         emailFuture = store.getCurrentEmail()
+            .exceptionally {
+                // The following recovers from the user receiving a push notification, then logging out
+                // and then clicking on the notification. In this case, the intent will contain the email
+                val pushNotificationEmail = intent.getStringExtra("pushNotification_currentUserEmail")!!
+                store.setCurrentEmail(pushNotificationEmail)
+                pushNotificationEmail
+            }
         val chatId = intent.getStringExtra("chatId")
         val isGroupChat: Boolean
         var contact = ""

--- a/app/src/main/java/com/github/sdpcoachme/messaging/InAppNotifier.kt
+++ b/app/src/main/java/com/github/sdpcoachme/messaging/InAppNotifier.kt
@@ -11,6 +11,7 @@ import com.github.sdpcoachme.auth.LoginActivity
 import com.github.sdpcoachme.database.CachingStore
 import com.github.sdpcoachme.profile.CoachesListActivity
 import com.google.firebase.messaging.FirebaseMessagingService
+import java.util.concurrent.CompletableFuture
 
 /**
  * This class is used to send in-app push notifications to the user while the app is in the foreground.
@@ -59,18 +60,27 @@ class InAppNotifier(val context: Context, val store: CachingStore) {
     private fun sendMessagingNotification(notificationTitle: String, notificationBody: String, chatId: String) {
 
         // The more info we receive, the more we can customize the notification's behaviour (up until the chat itself)
-        store.isLoggedIn().thenAccept { isLoggedIn ->
+        store.isLoggedIn().thenCompose { isLoggedIn ->
+            if (isLoggedIn) store.getCurrentEmail() else CompletableFuture.completedFuture("")
+        }.thenAccept { email ->
             val intent = when {
-                !isLoggedIn ->
+                email.isEmpty() ->
                     Intent(context, LoginActivity::class.java)
-                    .putExtra("chatId", chatId)
-                    .setAction("OPEN_CHAT_ACTIVITY")
+                        .putExtra("chatId", chatId)
+                        .setAction("OPEN_CHAT_ACTIVITY")
                 chatId.isEmpty() ->
                     Intent(context, CoachesListActivity::class.java)
-                    .putExtra("isViewingContacts", true)
+                        .putExtra("isViewingContacts", true)
+                        .putExtra("pushNotification_currentUserEmail", email)
                 else ->
-                    Intent(context, ChatActivity::class.java)
-                    .putExtra("chatId", chatId)
+                    Intent(context, CoachesListActivity::class.java)
+                        // openChat is added to make sure that the user goes bac to the CoachesListActivity
+                        // when clicking on the back button in the chat activity
+                        // I.e., with this boolean extra, the onCreate of the CoachesListActivity
+                        // will automatically redirect to the wanted chat.
+                        .putExtra("openChat", true)
+                        .putExtra("chatId", chatId)
+                        .putExtra("pushNotification_currentUserEmail", email)
             }
 
             // Create the pending intent to be used when the notification is clicked

--- a/app/src/main/java/com/github/sdpcoachme/messaging/InAppNotifier.kt
+++ b/app/src/main/java/com/github/sdpcoachme/messaging/InAppNotifier.kt
@@ -68,19 +68,17 @@ class InAppNotifier(val context: Context, val store: CachingStore) {
                     Intent(context, LoginActivity::class.java)
                         .putExtra("chatId", chatId)
                         .setAction("OPEN_CHAT_ACTIVITY")
-                chatId.isEmpty() ->
-                    Intent(context, CoachesListActivity::class.java)
+                else -> {
+                    val emailExistsIntent = Intent(context, CoachesListActivity::class.java)
                         .putExtra("isViewingContacts", true)
                         .putExtra("pushNotification_currentUserEmail", email)
-                else ->
-                    Intent(context, CoachesListActivity::class.java)
-                        // openChat is added to make sure that the user goes bac to the CoachesListActivity
-                        // when clicking on the back button in the chat activity
-                        // I.e., with this boolean extra, the onCreate of the CoachesListActivity
-                        // will automatically redirect to the wanted chat.
-                        .putExtra("openChat", true)
-                        .putExtra("chatId", chatId)
-                        .putExtra("pushNotification_currentUserEmail", email)
+                    if (chatId.isNotEmpty()) {
+                        emailExistsIntent
+                            .putExtra("openChat", true)
+                            .putExtra("chatId", chatId)
+                    }
+                    emailExistsIntent
+                }
             }
 
             // Create the pending intent to be used when the notification is clicked

--- a/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
+++ b/app/src/main/java/com/github/sdpcoachme/profile/CoachesListActivity.kt
@@ -61,10 +61,27 @@ class CoachesListActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        if (intent.getBooleanExtra("openChat", false)) {
+            val chatId = intent.getStringExtra("chatId")!!
+            val email = intent.getStringExtra("pushNotification_currentUserEmail")!!
+            val chatIntent = Intent(this, ChatActivity::class.java)
+                .putExtra("chatId", chatId)
+                .putExtra("pushNotification_currentUserEmail", email)
+            startActivity(chatIntent)
+        }
+
+
         val isViewingContacts = intent.getBooleanExtra("isViewingContacts", false)
         store = (application as CoachMeApplication).store
 
         emailFuture = store.getCurrentEmail()
+            .exceptionally {
+                // The following recovers from the user receiving a push notification, then logging out
+                // and then clicking on the notification. In this case, the intent will contain the email
+                val pushNotificationEmail = intent.getStringExtra("pushNotification_currentUserEmail")!!
+                store.setCurrentEmail(pushNotificationEmail)
+                pushNotificationEmail
+            }
 
         val locationProvider = (application as CoachMeApplication).locationProvider
         // Here we don't need the UserInfo


### PR DESCRIPTION
This pull request addresses the bug where the application would crash when the user logged out after receiving a push notification when inside the app and then clicked on it after having logged out. This crash happened as there was no user email in the application. This has been fixed now.

Also, the redirection of the user when clicking on the push notification has been adapted to route the user through the contacts listing activity to ensure that the app would not close on the back button press when freshly opening the application by clicking on the push notification. Now, when users click on the notification and then the back button, they will be redirected to the contacts listing.

The added changes have also been tested.